### PR TITLE
III-2876: Add option to keep certain labels when importing

### DIFF
--- a/src/LabelCollection.php
+++ b/src/LabelCollection.php
@@ -195,21 +195,4 @@ class LabelCollection implements \Countable
 
         return $labels;
     }
-
-    /**
-     * @return \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels
-     */
-    public function toModelLabels()
-    {
-        return new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels(
-            ...array_map(
-                function (Label $label) {
-                    return new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName((string) $label)
-                    );
-                },
-                $this->labels
-            )
-        );
-    }
 }

--- a/src/LabelCollection.php
+++ b/src/LabelCollection.php
@@ -195,4 +195,21 @@ class LabelCollection implements \Countable
 
         return $labels;
     }
+
+    /**
+     * @return \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels
+     */
+    public function toModelLabels()
+    {
+        return new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Labels(
+            ...array_map(
+                function (Label $label) {
+                    return new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\LabelName((string) $label)
+                    );
+                },
+                $this->labels
+            )
+        );
+    }
 }

--- a/src/Offer/Commands/AbstractImportLabels.php
+++ b/src/Offer/Commands/AbstractImportLabels.php
@@ -45,9 +45,20 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
     /**
      * @return Labels
      */
-    public function getLabels()
+    public function getLabelsToImport()
     {
-        return $this->labels;
+        $labelNamesToKeep = array_map(
+            function (Label $label) {
+                return $label->getName();
+            },
+            $this->labelsToKeepIfAlreadyOnOffer->toArray()
+        );
+
+        return $this->labels->filter(
+            function (Label $label) use ($labelNamesToKeep) {
+                return !in_array($label->getName(), $labelNamesToKeep);
+            }
+        );
     }
 
     /**
@@ -59,7 +70,7 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
             function (Label $label) {
                 return new StringLiteral($label->getName()->toString());
             },
-            $this->getLabels()->toArray()
+            $this->getLabelsToImport()->toArray()
         );
     }
 }

--- a/src/Offer/Commands/AbstractImportLabels.php
+++ b/src/Offer/Commands/AbstractImportLabels.php
@@ -15,6 +15,11 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
     private $labels;
 
     /**
+     * @var Labels
+     */
+    private $labelsToKeepIfAlreadyOnOffer;
+
+    /**
      * @param string $itemId
      * @param Labels $labels
      */
@@ -22,6 +27,19 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
     {
         parent::__construct($itemId);
         $this->labels = $labels;
+        $this->labelsToKeepIfAlreadyOnOffer = new Labels();
+    }
+
+    public function withLabelsToKeepIfAlreadyOnOffer(Labels $labels): self
+    {
+        $c = clone $this;
+        $c->labelsToKeepIfAlreadyOnOffer = $labels;
+        return $c;
+    }
+
+    public function getLabelsToKeepIfAlreadyOnOffer(): Labels
+    {
+        return $this->labelsToKeepIfAlreadyOnOffer;
     }
 
     /**

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -328,7 +328,7 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     {
         $offer = $this->load($importLabels->getItemId());
 
-        $offer->importLabels($importLabels->getLabels());
+        $offer->importLabels($importLabels->getLabels(), $importLabels->getLabelsToKeepIfAlreadyOnOffer());
 
         $this->offerRepository->save($offer);
     }

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -328,7 +328,7 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     {
         $offer = $this->load($importLabels->getItemId());
 
-        $offer->importLabels($importLabels->getLabels(), $importLabels->getLabelsToKeepIfAlreadyOnOffer());
+        $offer->importLabels($importLabels->getLabelsToImport(), $importLabels->getLabelsToKeepIfAlreadyOnOffer());
 
         $this->offerRepository->save($offer);
     }

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -51,7 +51,18 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
      */
     public function getLabels()
     {
-        return $this->labels;
+        $labelNamesToKeep = array_map(
+            function (Label $label) {
+                return $label->getName();
+            },
+            $this->labelsToKeepIfAlreadyOnOrganizer->toArray()
+        );
+
+        return $this->labels->filter(
+            function (Label $label) use ($labelNamesToKeep) {
+                return !in_array($label->getName(), $labelNamesToKeep);
+            }
+        );
     }
 
     /**

--- a/src/Organizer/Commands/ImportLabels.php
+++ b/src/Organizer/Commands/ImportLabels.php
@@ -17,6 +17,11 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
     private $labels;
 
     /**
+     * @var Labels
+     */
+    private $labelsToKeepIfAlreadyOnOrganizer;
+
+    /**
      * @param string $organizerId
      * @param Labels $label
      */
@@ -26,6 +31,19 @@ class ImportLabels extends AbstractOrganizerCommand implements AuthorizableComma
     ) {
         parent::__construct($organizerId);
         $this->labels = $label;
+        $this->labelsToKeepIfAlreadyOnOrganizer = new Labels();
+    }
+
+    public function withLabelsToKeepIfAlreadyOnOrganizer(Labels $labels): self
+    {
+        $c = clone $this;
+        $c->labelsToKeepIfAlreadyOnOrganizer = $labels;
+        return $c;
+    }
+
+    public function getLabelsToKeepIfAlreadyOnOrganizer(): Labels
+    {
+        return $this->labelsToKeepIfAlreadyOnOrganizer;
     }
 
     /**

--- a/src/Organizer/OrganizerCommandHandler.php
+++ b/src/Organizer/OrganizerCommandHandler.php
@@ -189,7 +189,7 @@ class OrganizerCommandHandler implements CommandHandlerInterface
     {
         $organizer = $this->loadOrganizer($importLabels->getOrganizerId());
 
-        $organizer->importLabels($importLabels->getLabels());
+        $organizer->importLabels($importLabels->getLabels(), $importLabels->getLabelsToKeepIfAlreadyOnOrganizer());
 
         $this->organizerRepository->save($organizer);
     }

--- a/test/Event/Commands/ImportLabelsTest.php
+++ b/test/Event/Commands/ImportLabelsTest.php
@@ -58,7 +58,7 @@ class ImportLabelsTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             $this->labels,
-            $this->importLabels->getLabels()
+            $this->importLabels->getLabelsToImport()
         );
     }
 

--- a/test/Offer/OfferCommandHandlerTest.php
+++ b/test/Offer/OfferCommandHandlerTest.php
@@ -249,33 +249,18 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
             ->given(
                 [
                     $this->itemCreated,
-                    new LabelAdded($this->id, new Label('existing1')),
-                    new LabelAdded($this->id, new Label('existing2')),
                 ]
             )
             ->when(
-                (
-                    new ImportLabels(
-                        $this->id,
-                        new Labels(
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('foo'),
-                                true
-                            ),
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('bar'),
-                                true
-                            ),
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('existing2'),
-                                true
-                            )
-                        )
-                    )
-                )->withLabelsToKeepIfAlreadyOnOffer(
+                new ImportLabels(
+                    $this->id,
                     new Labels(
                         new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('existing2'),
+                            new LabelName('foo'),
+                            true
+                        ),
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                            new LabelName('bar'),
                             true
                         )
                     )
@@ -298,7 +283,42 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
                     ),
                     new LabelAdded($this->id, new Label('foo')),
                     new LabelAdded($this->id, new Label('bar')),
-                    new LabelRemoved($this->id, new Label('existing1')),
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_not_replace_private_labels_that_are_already_on_the_offer()
+    {
+        $this->scenario
+            ->withAggregateId($this->id)
+            ->given(
+                [
+                    $this->itemCreated,
+                    new LabelAdded($this->id, new Label('existing_to_be_removed')),
+                    new LabelAdded($this->id, new Label('existing_private')),
+                ]
+            )
+            ->when(
+                (
+                    new ImportLabels(
+                        $this->id,
+                        new Labels()
+                    )
+                )->withLabelsToKeepIfAlreadyOnOffer(
+                    new Labels(
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                            new LabelName('existing_private'),
+                            true
+                        )
+                    )
+                )
+            )
+            ->then(
+                [
+                    new LabelRemoved($this->id, new Label('existing_to_be_removed')),
                 ]
             );
     }

--- a/test/Offer/OfferCommandHandlerTest.php
+++ b/test/Offer/OfferCommandHandlerTest.php
@@ -249,18 +249,29 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
             ->given(
                 [
                     $this->itemCreated,
+                    new LabelAdded($this->id, new Label('existing1')),
+                    new LabelAdded($this->id, new Label('existing2')),
                 ]
             )
             ->when(
-                new ImportLabels(
-                    $this->id,
+                (
+                    new ImportLabels(
+                        $this->id,
+                        new Labels(
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('foo'),
+                                true
+                            ),
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('bar'),
+                                true
+                            )
+                        )
+                    )
+                )->withLabelsToKeepIfAlreadyOnOffer(
                     new Labels(
                         new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('foo'),
-                            true
-                        ),
-                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('bar'),
+                            new LabelName('existing2'),
                             true
                         )
                     )
@@ -283,6 +294,7 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
                     ),
                     new LabelAdded($this->id, new Label('foo')),
                     new LabelAdded($this->id, new Label('bar')),
+                    new LabelRemoved($this->id, new Label('existing1')),
                 ]
             );
     }

--- a/test/Offer/OfferCommandHandlerTest.php
+++ b/test/Offer/OfferCommandHandlerTest.php
@@ -265,6 +265,10 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
                             new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
                                 new LabelName('bar'),
                                 true
+                            ),
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('existing2'),
+                                true
                             )
                         )
                     )

--- a/test/Offer/OfferTest.php
+++ b/test/Offer/OfferTest.php
@@ -379,16 +379,24 @@ class OfferTest extends AggregateRootScenarioTestCase
             )
         );
 
+        $labelsToKeepIfApplied = new Labels(
+            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                new LabelName('existing_label_3'),
+                true
+            )
+        );
+
         $this->scenario
             ->given([
                 new ItemCreated($itemId),
                 new LabelAdded($itemId, new Label('existing_label_1')),
                 new LabelAdded($itemId, new Label('existing_label_2')),
+                new LabelAdded($itemId, new Label('existing_label_3')),
             ])
             ->when(
-                function (Item $item) use ($labels) {
-                    $item->importLabels($labels);
-                    $item->importLabels($labels);
+                function (Item $item) use ($labels, $labelsToKeepIfApplied) {
+                    $item->importLabels($labels, $labelsToKeepIfApplied);
+                    $item->importLabels($labels, $labelsToKeepIfApplied);
                 }
             )
             ->then([

--- a/test/Organizer/OrganizerCommandHandlerTest.php
+++ b/test/Organizer/OrganizerCommandHandlerTest.php
@@ -475,19 +475,29 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
             ->given(
                 [
                     $this->organizerCreated,
+                    new LabelAdded($organizerId, new Label('existing1')),
+                    new LabelAdded($organizerId, new Label('existing2')),
                 ]
             )
             ->when(
-                new ImportLabels(
-                    $organizerId,
+                (
+                    new ImportLabels(
+                        $organizerId,
+                        new Labels(
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('foo'),
+                                true
+                            ),
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('bar'),
+                                true
+                            )
+                        )
+                    )
+                )->withLabelsToKeepIfAlreadyOnOrganizer(
                     new Labels(
                         new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('foo'),
-                            true
-                        ),
-                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('bar'),
-                            true
+                            new LabelName('existing2')
                         )
                     )
                 )
@@ -509,6 +519,7 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
                     ),
                     new LabelAdded($organizerId, new Label('foo')),
                     new LabelAdded($organizerId, new Label('bar')),
+                    new LabelRemoved($organizerId, new Label('existing1')),
                 ]
             );
     }

--- a/test/Organizer/OrganizerCommandHandlerTest.php
+++ b/test/Organizer/OrganizerCommandHandlerTest.php
@@ -475,32 +475,19 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
             ->given(
                 [
                     $this->organizerCreated,
-                    new LabelAdded($organizerId, new Label('existing1')),
-                    new LabelAdded($organizerId, new Label('existing2')),
                 ]
             )
             ->when(
-                (
-                    new ImportLabels(
-                        $organizerId,
-                        new Labels(
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('foo'),
-                                true
-                            ),
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('bar'),
-                                true
-                            ),
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('existing2')
-                            )
-                        )
-                    )
-                )->withLabelsToKeepIfAlreadyOnOrganizer(
+                new ImportLabels(
+                    $organizerId,
                     new Labels(
                         new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                            new LabelName('existing2')
+                            new LabelName('foo'),
+                            true
+                        ),
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                            new LabelName('bar'),
+                            true
                         )
                     )
                 )
@@ -522,10 +509,47 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
                     ),
                     new LabelAdded($organizerId, new Label('foo')),
                     new LabelAdded($organizerId, new Label('bar')),
-                    new LabelRemoved($organizerId, new Label('existing1')),
                 ]
             );
     }
+
+    /**
+     * @test
+     */
+    public function it_will_not_replace_private_labels_that_are_already_on_the_organizer()
+    {
+        $organizerId = $this->organizerCreated->getOrganizerId();
+
+        $this->scenario
+            ->withAggregateId($organizerId)
+            ->given(
+                [
+                    $this->organizerCreated,
+                    new LabelAdded($organizerId, new Label('existing_to_be_removed')),
+                    new LabelAdded($organizerId, new Label('existing_private')),
+                ]
+            )
+            ->when(
+                (
+                    new ImportLabels(
+                        $organizerId,
+                        new Labels()
+                    )
+                )->withLabelsToKeepIfAlreadyOnOrganizer(
+                    new Labels(
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                            new LabelName('existing_private')
+                        )
+                    )
+                )
+            )
+            ->then(
+                [
+                    new LabelRemoved($organizerId, new Label('existing_to_be_removed')),
+                ]
+            );
+    }
+
 
     /**
      * @test

--- a/test/Organizer/OrganizerCommandHandlerTest.php
+++ b/test/Organizer/OrganizerCommandHandlerTest.php
@@ -491,6 +491,9 @@ class OrganizerCommandHandlerTest extends CommandHandlerScenarioTestCase
                             new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
                                 new LabelName('bar'),
                                 true
+                            ),
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('existing2')
                             )
                         )
                     )

--- a/test/Organizer/OrganizerTest.php
+++ b/test/Organizer/OrganizerTest.php
@@ -177,6 +177,17 @@ class OrganizerTest extends AggregateRootScenarioTestCase
             )
         );
 
+        $keepIfApplied = new Labels(
+            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                new LabelName('existing_label_3'),
+                true
+            ),
+            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                new LabelName('non_existing_label_1'),
+                true
+            )
+        );
+
         $this->scenario
             ->withAggregateId($this->id)
             ->given(
@@ -184,12 +195,13 @@ class OrganizerTest extends AggregateRootScenarioTestCase
                     $this->organizerCreatedWithUniqueWebsite,
                     new LabelAdded($this->id, new Label('existing_label_1')),
                     new LabelAdded($this->id, new Label('existing_label_2')),
+                    new LabelAdded($this->id, new Label('existing_label_3')),
                 ]
             )
             ->when(
-                function (Organizer $organizer) use ($labels) {
-                    $organizer->importLabels($labels);
-                    $organizer->importLabels($labels);
+                function (Organizer $organizer) use ($labels, $keepIfApplied) {
+                    $organizer->importLabels($labels, $keepIfApplied);
+                    $organizer->importLabels($labels, $keepIfApplied);
                 }
             )
             ->then(


### PR DESCRIPTION
Any labels in this option will be kept if already applied on the offer in the past. If not they will be ignored.

These labels are not checked by the label security checks since either they are already on the offer or they are ignored.