### PR TITLE
III-2917 Setup query constraint column as longtext

### DIFF
--- a/src/Role/ReadModel/Search/Doctrine/SchemaConfigurator.php
+++ b/src/Role/ReadModel/Search/Doctrine/SchemaConfigurator.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3\Role\ReadModel\Search\Doctrine;
 
 use CultuurNet\UDB3\Doctrine\DBAL\SchemaConfiguratorInterface;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;
@@ -59,7 +60,8 @@ class SchemaConfigurator implements SchemaConfiguratorInterface
             ->setLength(255)
             ->setNotnull(true);
 
-        $table->addColumn(self::CONSTRAINT_COLUMN, Type::STRING)
+        $table->addColumn(self::CONSTRAINT_COLUMN, Type::TEXT)
+            ->setLength(MySqlPlatform::LENGTH_LIMIT_TEXT + 1)
             ->setNotnull(false);
 
         $table->setPrimaryKey([self::UUID_COLUMN]);


### PR DESCRIPTION
These schema classes are no longer being used to set up the actual application tables since https://bitbucket.org/cultuurnet/udb3-vagrant/pull-requests/60, but they're still being used for integration tests at this point.