### PR TITLE
III-2921 Add workflowStatus to active organizers

### DIFF
--- a/src/Organizer/OrganizerLDProjector.php
+++ b/src/Organizer/OrganizerLDProjector.php
@@ -14,7 +14,6 @@ use CultuurNet\UDB3\EventHandling\DelegateEventHandlingToSpecificMethodTrait;
 use CultuurNet\UDB3\Iri\IriGeneratorInterface;
 use CultuurNet\UDB3\Label;
 use CultuurNet\UDB3\Language;
-use CultuurNet\UDB3\Offer\WorkflowStatus;
 use CultuurNet\UDB3\Organizer\Events\AddressTranslated;
 use CultuurNet\UDB3\Organizer\Events\AddressUpdated;
 use CultuurNet\UDB3\Organizer\Events\ContactPointUpdated;
@@ -139,14 +138,16 @@ class OrganizerLDProjector implements EventListenerInterface
         );
 
         $document = $this->newDocument($organizerImportedFromUDB2->getActorId());
-        $actorLd = $document->getBody();
+        $jsonLD = $document->getBody();
 
-        $actorLd = $this->cdbXMLImporter->documentWithCdbXML(
-            $actorLd,
+        $jsonLD = $this->cdbXMLImporter->documentWithCdbXML(
+            $jsonLD,
             $udb2Actor
         );
 
-        return $document->withBody($actorLd);
+        $jsonLD->workflowStatus = WorkflowStatus::ACTIVE()->getName();
+
+        return $document->withBody($jsonLD);
     }
 
     /**
@@ -188,6 +189,8 @@ class OrganizerLDProjector implements EventListenerInterface
         )->format('c');
 
         $jsonLD = $this->appendCreator($jsonLD, $domainMessage);
+
+        $jsonLD->workflowStatus = WorkflowStatus::ACTIVE()->getName();
 
         return $document->withBody($jsonLD);
     }
@@ -241,6 +244,8 @@ class OrganizerLDProjector implements EventListenerInterface
         )->format('c');
 
         $jsonLD = $this->appendCreator($jsonLD, $domainMessage);
+
+        $jsonLD->workflowStatus = WorkflowStatus::ACTIVE()->getName();
 
         return $document->withBody($jsonLD);
     }

--- a/src/Organizer/WorkflowStatus.php
+++ b/src/Organizer/WorkflowStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Organizer;
+
+use MabeEnum\Enum;
+
+/**
+ * @method static WorkflowStatus ACTIVE()
+ * @method static WorkflowStatus DELETED()
+ */
+final class WorkflowStatus extends Enum
+{
+    const ACTIVE = 'active';
+    const DELETED = 'deleted';
+}

--- a/test/Organizer/OrganizerLDProjectorTest.php
+++ b/test/Organizer/OrganizerLDProjectorTest.php
@@ -172,6 +172,7 @@ class OrganizerLDProjectorTest extends \PHPUnit_Framework_TestCase
         $jsonLD->url = ['http://www.google.be'];
         $jsonLD->created = $this->recordedOn->toString();
         $jsonLD->creator = '28f69301-13bc-4153-a9d2-e91e89cbe156';
+        $jsonLD->workflowStatus = 'ACTIVE';
         $jsonLD->languages = ['nl'];
         $jsonLD->completedLanguages = ['nl'];
         $jsonLD->modified = $this->recordedOn->toString();
@@ -222,6 +223,7 @@ class OrganizerLDProjectorTest extends \PHPUnit_Framework_TestCase
         $jsonLD->name['en'] = 'some representative title';
         $jsonLD->created = $this->recordedOn->toString();
         $jsonLD->creator = '28f69301-13bc-4153-a9d2-e91e89cbe156';
+        $jsonLD->workflowStatus = 'ACTIVE';
         $jsonLD->languages = ['en'];
         $jsonLD->completedLanguages = ['en'];
         $jsonLD->modified = $this->recordedOn->toString();


### PR DESCRIPTION
### Added

- Added `workflowStatus: active` property to active organizers' json-ld

-------------------------------------------------

⚠️ This will require a `composer up cultuurnet/udb3` in `udb3-silex` after it gets merged.