### PR TITLE
Loosen up version constraint on guzzlehttp/psr7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "symfony/http-foundation": "~2.7.2",
     "justinrainbow/json-schema": "1.4.3",
     "php-http/httplug": "^1.0",
-    "guzzlehttp/psr7": "~1.2.3",
+    "guzzlehttp/psr7": "^1.2",
     "commerceguys/intl": "^0.7.1",
     "ramsey/uuid": "^2.9",
     "cakephp/chronos": "^1.1",


### PR DESCRIPTION
### Changed
- `guzzlehttp/psr7` is now constrained to `^1.2` instead of `~1.2.3`, allowing us to upgrade to `1.4` in applications that want to upgrade `guzzlehttp/guzzle` to version `6.3` and up.
