### PR TITLE
III-3051 - Don't allow updating with incompatible audienceType when using dummy place in event

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -322,6 +322,11 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
     public function updateAudience(
         Audience $audience
     ) {
+        $audienceType = $audience->getAudienceType();
+        if ($this->locationId->isDummyPlaceForEducation() && !$audienceType->sameValueAs(AudienceType::EDUCATION())) {
+            throw IncompatibleAudienceType::forEvent($this->eventId, $audienceType);
+        }
+
         if (is_null($this->audience) || !$this->audience->equals($audience)) {
             $this->apply(new AudienceUpdated(
                 $this->eventId,

--- a/src/Event/IncompatibleAudienceType.php
+++ b/src/Event/IncompatibleAudienceType.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace CultuurNet\UDB3\Event;
+
+use CultuurNet\UDB3\Event\ValueObjects\AudienceType;
+use Exception;
+
+final class IncompatibleAudienceType extends Exception
+{
+    public static function forEvent(string $eventId, AudienceType $audienceType)
+    {
+        return new self('Audience type ' . $audienceType->toNative() . ' is incompatible with event ' . $eventId);
+    }
+}

--- a/src/Event/ValueObjects/LocationId.php
+++ b/src/Event/ValueObjects/LocationId.php
@@ -6,6 +6,8 @@ use ValueObjects\StringLiteral\StringLiteral;
 
 class LocationId extends StringLiteral
 {
+    private static $dummyPlaceForEducationIds = [];
+
     public function __construct($value)
     {
         parent::__construct($value);
@@ -13,5 +15,15 @@ class LocationId extends StringLiteral
         if (empty($value)) {
             throw new \InvalidArgumentException('LocationId can\'t have an empty value.');
         }
+    }
+
+    public function isDummyPlaceForEducation(): bool
+    {
+        return in_array($this->value, self::$dummyPlaceForEducationIds);
+    }
+
+    public static function setDummyPlaceForEducationIds(array $dummyPlaceForEducationIds): void
+    {
+        self::$dummyPlaceForEducationIds = $dummyPlaceForEducationIds;
     }
 }

--- a/test/Event/EventTest.php
+++ b/test/Event/EventTest.php
@@ -934,6 +934,29 @@ class EventTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
+     */
+    public function it_will_not_update_audience_for_events_with_dummy_place(): void
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+        $dummyLocationId = Uuid::generateAsString();
+        LocationId::setDummyPlaceForEducationIds([$dummyLocationId]);
+        $this->expectException(IncompatibleAudienceType::class);
+        $this->scenario
+            ->given([
+                $this->getCreationEvent(),
+                new AudienceUpdated($eventId, new Audience(AudienceType::EDUCATION())),
+                new LocationUpdated($eventId, new LocationId($dummyLocationId)),
+            ])
+            ->when(
+                function (Event $event) {
+                    $event->updateAudience(new Audience(AudienceType::EVERYONE()));
+                }
+            )
+            ->then([]);
+    }
+
+    /**
+     * @test
      * @group issue-III-1380
      */
     public function it_refuses_to_copy_when_there_are_uncommitted_events()


### PR DESCRIPTION
### Changed
- When an event uses a dummy place for bookable events (for education), we no longer allow changing the audience type to something other than education.

---
Ticket: https://jira.uitdatabank.be/browse/III-3051

---
Note: This still requires bootstrapping in `udb3-silex` to statically set the list of dummy locations on the `LocationId` value object