### PR TITLE
Automatically set audienceType to education for events with a dummy location

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -311,8 +311,18 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
      */
     public function updateLocation(LocationId $locationId)
     {
-        if (is_null($this->locationId) || !$this->locationId->sameValueAs($locationId)) {
-            $this->apply(new LocationUpdated($this->eventId, $locationId));
+        if (!is_null($this->locationId) && $this->locationId->sameValueAs($locationId)) {
+            return;
+        }
+
+        $this->apply(new LocationUpdated($this->eventId, $locationId));
+
+        if ($locationId->isDummyPlaceForEducation()) {
+            // Bookable education events should get education as their audience type. We record this explicitly so we
+            // don't have to handle this edge case in every read model projector.
+            $this->apply(
+                new AudienceUpdated($this->eventId, new Audience(AudienceType::EDUCATION()))
+            );
         }
     }
 

--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -135,6 +135,14 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
             )
         );
 
+        if ($location->isDummyPlaceForEducation()) {
+            // Bookable education events should get education as their audience type. We record this explicitly so we
+            // don't have to handle this edge case in every read model projector.
+            $event->apply(
+                new AudienceUpdated($eventId, new Audience(AudienceType::EDUCATION()))
+            );
+        }
+
         return $event;
     }
 

--- a/test/Event/EventTest.php
+++ b/test/Event/EventTest.php
@@ -131,11 +131,12 @@ class EventTest extends AggregateRootScenarioTestCase
      */
     public function it_sets_the_audience_type_to_education_when_creating_an_event_with_a_dummy_education_location()
     {
+        $eventUuid = UUID::generateAsString();
         $locationUuid = UUID::generateAsString();
         LocationId::setDummyPlaceForEducationIds([$locationUuid]);
 
         $event = Event::create(
-            'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
+            $eventUuid,
             new Language('en'),
             new Title('some representative title'),
             new EventType('0.50.4.0.0', 'concert'),
@@ -143,10 +144,7 @@ class EventTest extends AggregateRootScenarioTestCase
             new Calendar(CalendarType::PERMANENT())
         );
 
-        $expectedEvent = new AudienceUpdated(
-            'd2b41f1d-598c-46af-a3a5-10e373faa6fe',
-            new Audience(AudienceType::EDUCATION())
-        );
+        $expectedEvent = new AudienceUpdated($eventUuid, new Audience(AudienceType::EDUCATION()));
 
         $actualEvents = array_map(
             function (DomainMessage $domainMessage) {
@@ -891,9 +889,9 @@ class EventTest extends AggregateRootScenarioTestCase
      */
     public function it_sets_the_audience_type_to_education_when_setting_a_dummy_education_location()
     {
-        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
         $createEvent = $this->getCreationEvent();
-        $newLocationId = new LocationId('57738178-28a5-4afb-90c0-fd0beba172a8');
+        $eventId = $createEvent->getEventId();
+        $newLocationId = new LocationId(UUID::generateAsString());
         LocationId::setDummyPlaceForEducationIds([$newLocationId->toNative()]);
 
         $this->scenario

--- a/test/Event/EventTest.php
+++ b/test/Event/EventTest.php
@@ -888,6 +888,35 @@ class EventTest extends AggregateRootScenarioTestCase
 
     /**
      * @test
+     */
+    public function it_sets_the_audience_type_to_education_when_setting_a_dummy_education_location()
+    {
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+        $createEvent = $this->getCreationEvent();
+        $newLocationId = new LocationId('57738178-28a5-4afb-90c0-fd0beba172a8');
+        LocationId::setDummyPlaceForEducationIds([$newLocationId->toNative()]);
+
+        $this->scenario
+            ->given(
+                [
+                    $createEvent,
+                ]
+            )
+            ->when(
+                function (Event $event) use ($newLocationId) {
+                    $event->updateLocation($newLocationId);
+                }
+            )
+            ->then(
+                [
+                    new LocationUpdated($eventId, $newLocationId),
+                    new AudienceUpdated($eventId, new Audience(AudienceType::EDUCATION()))
+                ]
+            );
+    }
+
+    /**
+     * @test
      * @dataProvider audienceDataProvider
      * @param Audience[] $audiences
      * @param AudienceUpdated[] $audienceUpdatedEvents


### PR DESCRIPTION
### Changed

- When creating an event with a dummy education location, the event's audience type will automatically be set to education.
- When updating an event to link it to a dummy education location, the event's audience type will automatically be set to education.

---

Ticket: https://jira.uitdatabank.be/browse/III-3050