### PR TITLE
III-3043 Update events with a place that was marked as duplicate

### DIFF
--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event;
+
+use Broadway\CommandHandling\CommandBusInterface;
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListenerInterface;
+use CultuurNet\UDB3\Event\Commands\UpdateLocation;
+use CultuurNet\UDB3\Event\ReadModel\Relations\RepositoryInterface;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
+
+final class LocationMarkedAsDuplicateProcessManager implements EventListenerInterface
+{
+    /**
+     * @var RepositoryInterface
+     */
+    private $relationsRepository;
+
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    public function __construct(
+        RepositoryInterface $relationsRepository,
+        CommandBusInterface $commandBus
+    ) {
+        $this->relationsRepository = $relationsRepository;
+        $this->commandBus = $commandBus;
+    }
+
+    public function handle(DomainMessage $domainMessage)
+    {
+        $domainEvent = $domainMessage->getPayload();
+
+        // Only handle (Place)MarkedAsDuplicate events.
+        if (!($domainEvent instanceof MarkedAsDuplicate)) {
+            return;
+        }
+
+        $duplicatePlaceId = $domainEvent->getPlaceId();
+        $canonicalPlaceId = $domainEvent->getDuplicateOf();
+
+        $eventIds = $this->relationsRepository->getEventsLocatedAtPlace($duplicatePlaceId);
+
+        foreach ($eventIds as $eventId) {
+            $this->commandBus->dispatch(
+                new UpdateLocation($eventId, new LocationId($canonicalPlaceId))
+            );
+        }
+    }
+}

--- a/test/Event/LocationMarkedAsDuplicateProcessManagerTest.php
+++ b/test/Event/LocationMarkedAsDuplicateProcessManagerTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace CultuurNet\UDB3\Event;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Event\Commands\UpdateLocation;
+use CultuurNet\UDB3\Event\ReadModel\Relations\RepositoryInterface;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Place\Events\MarkedAsCanonical;
+use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LocationMarkedAsDuplicateProcessManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var RepositoryInterface|MockObject
+     */
+    private $relationsRepository;
+
+    /**
+     * @var TraceableCommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var LocationMarkedAsDuplicateProcessManager
+     */
+    private $processManager;
+
+    protected function setUp()
+    {
+        $this->relationsRepository = $this->createMock(RepositoryInterface::class);
+        $this->commandBus = new TraceableCommandBus();
+
+        $this->processManager = new LocationMarkedAsDuplicateProcessManager(
+            $this->relationsRepository,
+            $this->commandBus
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_should_only_handle_place_marked_as_duplicate_events()
+    {
+        $this->relationsRepository->expects($this->never())
+            ->method('getEventsLocatedAtPlace');
+
+        $this->commandBus->record();
+
+        $this->processManager->handle(
+            DomainMessage::recordNow(
+                '110ecece-f6b0-4360-b5c5-c95babcfe045',
+                0,
+                Metadata::deserialize([]),
+                new MarkedAsCanonical(
+                    '110ecece-f6b0-4360-b5c5-c95babcfe045',
+                    'ab72ffd9-8789-4c35-b6ba-b702643a29b9'
+                )
+            )
+        );
+
+        $this->assertEquals([], $this->commandBus->getRecordedCommands());
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_every_event_with_a_location_that_is_marked_as_duplicate_to_the_canonical_location()
+    {
+        $this->relationsRepository->expects($this->once())
+            ->method('getEventsLocatedAtPlace')
+            ->with('110ecece-f6b0-4360-b5c5-c95babcfe045')
+            ->willReturn([
+                'c393e98b-b33e-4948-b97a-3c48e3748398',
+                'd8835de7-c84d-417b-a173-079401f29fde',
+                '13ca4b6b-92b0-407d-b472-634dd0e654d0',
+            ]);
+
+        $this->commandBus->record();
+
+        $duplicateLocationId = '110ecece-f6b0-4360-b5c5-c95babcfe045';
+        $canonicalLocationId = 'ab72ffd9-8789-4c35-b6ba-b702643a29b9';
+
+        $this->processManager->handle(
+            DomainMessage::recordNow(
+                $duplicateLocationId,
+                0,
+                Metadata::deserialize([]),
+                new MarkedAsDuplicate($duplicateLocationId, $canonicalLocationId)
+            )
+        );
+
+        $expected = [
+            new UpdateLocation('c393e98b-b33e-4948-b97a-3c48e3748398', new LocationId($canonicalLocationId)),
+            new UpdateLocation('d8835de7-c84d-417b-a173-079401f29fde', new LocationId($canonicalLocationId)),
+            new UpdateLocation('13ca4b6b-92b0-407d-b472-634dd0e654d0', new LocationId($canonicalLocationId)),
+        ];
+
+        $this->assertEquals($expected, $this->commandBus->getRecordedCommands());
+    }
+}


### PR DESCRIPTION
### Added

- Process manager that updates events who's place was marked as duplicate, to change it to the canonical place.

---

Ticket: https://jira.uitdatabank.be/browse/III-3043

---

This will also need to be bootstrapped in udb3-silex. I've updated https://jira.uitdatabank.be/browse/III-3045 to mention that it will require some bootstrapping when we add the console command.