### PR TITLE
III-3060 - Project duplicates of duplicate in read models for search indexing

### DIFF
--- a/src/Place/Events/MarkedAsCanonical.php
+++ b/src/Place/Events/MarkedAsCanonical.php
@@ -11,10 +11,16 @@ final class MarkedAsCanonical extends PlaceEvent
      */
     private $duplicatedBy;
 
-    public function __construct(string $placeId, string $duplicatedBy)
+    /**
+     * @var string[]
+     */
+    private $duplicatesOfDuplicate = [];
+
+    public function __construct(string $placeId, string $duplicatedBy, array $duplicatesOfDuplicate = [])
     {
         parent::__construct($placeId);
         $this->duplicatedBy = $duplicatedBy;
+        $this->duplicatesOfDuplicate = $duplicatesOfDuplicate;
     }
 
     public function getDuplicatedBy(): string
@@ -22,15 +28,24 @@ final class MarkedAsCanonical extends PlaceEvent
         return $this->duplicatedBy;
     }
 
+    /**
+     * @return string[]
+     */
+    public function getDuplicatesOfDuplicate(): array
+    {
+        return $this->duplicatesOfDuplicate;
+    }
+
     public function serialize()
     {
         return parent::serialize() + [
-                'duplicated_by' => $this->duplicatedBy,
-            ];
+            'duplicated_by' => $this->duplicatedBy,
+            'duplicates_of_duplicate' => $this->duplicatesOfDuplicate,
+        ];
     }
 
     public static function deserialize(array $data)
     {
-        return new static($data['place_id'], ($data['duplicated_by']));
+        return new static($data['place_id'], $data['duplicated_by'], $data['duplicates_of_duplicate']);
     }
 }

--- a/src/Place/MarkAsDuplicateCommandHandler.php
+++ b/src/Place/MarkAsDuplicateCommandHandler.php
@@ -26,7 +26,7 @@ class MarkAsDuplicateCommandHandler extends Udb3CommandHandler
         $placeToMarkAsMaster = $this->repository->load($command->getCanonicalPlaceId());
 
         $placeToMarkAsDuplicate->markAsDuplicateOf($command->getCanonicalPlaceId());
-        $placeToMarkAsMaster->markAsCanonicalFor($command->getDuplicatePlaceId());
+        $placeToMarkAsMaster->markAsCanonicalFor($command->getDuplicatePlaceId(), $placeToMarkAsDuplicate->getDuplicates());
 
         $this->repository->saveMultiple($placeToMarkAsDuplicate, $placeToMarkAsMaster);
     }

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -219,6 +219,14 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
         $this->apply(new MarkedAsCanonical($this->placeId, $placeIdOfDuplicate));
     }
 
+    /**
+     * @return string[]
+     */
+    public function getDuplicates(): array
+    {
+        return $this->duplicates;
+    }
+
     private function allowAddressUpdate(Address $address, Language $language): bool
     {
         // No current address in the provided language so update with new address is allowed.

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -84,6 +84,11 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
      */
     private $isDuplicate = false;
 
+    /**
+     * @var string[]
+     */
+    private $duplicates = [];
+
     public function __construct()
     {
         parent::__construct();
@@ -321,6 +326,11 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
     protected function applyMarkedAsDuplicate(MarkedAsDuplicate $event): void
     {
         $this->isDuplicate = true;
+    }
+
+    protected function applyMarkedAsCanonical(MarkedAsCanonical $event): void
+    {
+        $this->duplicates[] = $event->getDuplicatedBy();
     }
 
     /**

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -339,6 +339,9 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
     protected function applyMarkedAsCanonical(MarkedAsCanonical $event): void
     {
         $this->duplicates[] = $event->getDuplicatedBy();
+        foreach ($event->getDuplicatesOfDuplicate() as $duplicateOfDuplicate) {
+            $this->duplicates[] = $duplicateOfDuplicate;
+        }
     }
 
     /**

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -206,7 +206,7 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
         $this->apply(new MarkedAsDuplicate($this->placeId, $placeIdOfCanonical));
     }
 
-    public function markAsCanonicalFor(string $placeIdOfDuplicate): void
+    public function markAsCanonicalFor(string $placeIdOfDuplicate, array $duplicatesOfDuplicate = []): void
     {
         if ($this->isDeleted) {
             throw CannotMarkPlaceAsCanonical::becauseItIsDeleted($this->placeId);
@@ -216,7 +216,7 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
             throw CannotMarkPlaceAsCanonical::becauseItIsAlreadyADuplicate($this->placeId);
         }
 
-        $this->apply(new MarkedAsCanonical($this->placeId, $placeIdOfDuplicate));
+        $this->apply(new MarkedAsCanonical($this->placeId, $placeIdOfDuplicate, $duplicatesOfDuplicate));
     }
 
     /**

--- a/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
+++ b/src/Place/ReadModel/JSONLD/PlaceLDProjector.php
@@ -394,6 +394,9 @@ class PlaceLDProjector extends OfferLDProjector implements EventListenerInterfac
 
         return $document->apply(function ($placeLd) use ($markedAsCanonical) {
             $placeLd->duplicatedBy[] = $this->iriGenerator->iri($markedAsCanonical->getDuplicatedBy());
+            foreach ($markedAsCanonical->getDuplicatesOfDuplicate() as $duplicateOfDuplicate) {
+                $placeLd->duplicatedBy[] = $this->iriGenerator->iri($duplicateOfDuplicate);
+            }
             return $placeLd;
         });
     }

--- a/test/Place/Events/MarkedAsCanonicalTest.php
+++ b/test/Place/Events/MarkedAsCanonicalTest.php
@@ -13,12 +13,20 @@ final class MarkedAsCanonicalTest extends TestCase
     {
         $event = new MarkedAsCanonical(
             'a9088117-5ec8-4117-8ce0-5ce27e685055',
-            '7ee54099-9e0f-4c55-9a28-b548ef2a41ba'
+            '7ee54099-9e0f-4c55-9a28-b548ef2a41ba',
+            [
+                '4de29c86-6c91-4fe4-81e8-167dbcae3de8',
+                'f199bd45-b40f-4cd9-bd15-7d302f8935ab',
+            ]
         );
 
         $eventAsArray = [
             'place_id' => 'a9088117-5ec8-4117-8ce0-5ce27e685055',
             'duplicated_by' => '7ee54099-9e0f-4c55-9a28-b548ef2a41ba',
+            'duplicates_of_duplicate' => [
+                '4de29c86-6c91-4fe4-81e8-167dbcae3de8',
+                'f199bd45-b40f-4cd9-bd15-7d302f8935ab',
+            ],
         ];
 
         $serializedEvent = $event->serialize();

--- a/test/Place/Events/MarkedAsCanonicalTest.php
+++ b/test/Place/Events/MarkedAsCanonicalTest.php
@@ -4,7 +4,7 @@ namespace CultuurNet\UDB3\Place\Events;
 
 use PHPUnit\Framework\TestCase;
 
-final class MarkedAsMasterTest extends TestCase
+final class MarkedAsCanonicalTest extends TestCase
 {
     /**
      * @test

--- a/test/Place/PlaceTest.php
+++ b/test/Place/PlaceTest.php
@@ -804,15 +804,22 @@ class PlaceTest extends AggregateRootScenarioTestCase
         $placeCreated = $this->createPlaceCreatedEvent();
         $placeId = $placeCreated->getPlaceId();
         $duplicatePlaceId = 'ef694e51-9ac6-4f45-be25-5207ba6ec9dc';
+        $duplicateOfDuplicate1 = \ValueObjects\Identity\UUID::generateAsString();
+        $duplicateOfDuplicate2 = \ValueObjects\Identity\UUID::generateAsString();
+        $duplicatesOfDuplicate = [$duplicateOfDuplicate1, $duplicateOfDuplicate2];
         $this->scenario
             ->withAggregateId('c5c1b435-0f3c-4b75-9f28-94d93be7078b')
             ->given([$placeCreated])
             ->when(
-                function (Place $place) use ($duplicatePlaceId) {
-                    $place->markAsCanonicalFor($duplicatePlaceId);
+                function (Place $place) use ($duplicatePlaceId, $duplicatesOfDuplicate) {
+                    $place->markAsCanonicalFor($duplicatePlaceId, $duplicatesOfDuplicate);
                 }
             )
-            ->then([new MarkedAsCanonical($placeId, $duplicatePlaceId)]);
+            ->then(
+                [
+                    new MarkedAsCanonical($placeId, $duplicatePlaceId, $duplicatesOfDuplicate),
+                ]
+            );
     }
 
     /**


### PR DESCRIPTION
### Changed
- Duplicates of a duplicate will now be passed along when marking a place as canonical. This will make sure search will always return events for the proper canonical.

---
Ticket: https://jira.uitdatabank.be/browse/III-3060