### PR TITLE
III-3047 - Always use canonical place when creating or updating an event

### DIFF
--- a/src/Event/RelocateEventToCanonicalPlace.php
+++ b/src/Event/RelocateEventToCanonicalPlace.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace CultuurNet\UDB3\Event;
+
+use Broadway\CommandHandling\CommandBusInterface;
+use Broadway\Domain\DomainMessage;
+use Broadway\EventHandling\EventListenerInterface;
+use CultuurNet\UDB3\Event\Commands\UpdateLocation;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\LocationUpdated;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Place\CanonicalPlaceRepository;
+
+final class RelocateEventToCanonicalPlace implements EventListenerInterface
+{
+    /**
+     * @var CommandBusInterface
+     */
+    private $commandBus;
+
+    /**
+     * @var CanonicalPlaceRepository
+     */
+    private $canonicalPlaceRepository;
+
+    public function __construct(CommandBusInterface $commandBus, CanonicalPlaceRepository $canonicalPlaceRepository)
+    {
+        $this->commandBus = $commandBus;
+        $this->canonicalPlaceRepository = $canonicalPlaceRepository;
+    }
+
+    public function handle(DomainMessage $domainMessage)
+    {
+        $event = $domainMessage->getPayload();
+        switch (true) {
+            case $event instanceof EventCreated:
+                $this->handleEventCreated($event);
+                break;
+            case $event instanceof LocationUpdated:
+                $this->handleLocationUpdated($event);
+                break;
+            default:
+                return;
+        }
+    }
+
+    private function handleEventCreated(EventCreated $event): void
+    {
+        $this->relocateEventToCanonicalPlace($event->getEventId(), $event->getLocation());
+    }
+
+    private function handleLocationUpdated(LocationUpdated $event): void
+    {
+        $this->relocateEventToCanonicalPlace($event->getItemId(), $event->getLocationId());
+    }
+
+    private function relocateEventToCanonicalPlace(string $eventId, LocationId $locationId): void
+    {
+        $place = $this->canonicalPlaceRepository->findCanonicalFor($locationId->toNative());
+        $canonicalPlace = new LocationId($place->getAggregateRootId());
+        if ($locationId->sameValueAs($canonicalPlace)) {
+            return;
+        }
+
+        $this->commandBus->dispatch(new UpdateLocation($eventId, $canonicalPlace));
+    }
+}

--- a/src/Place/CanonicalPlaceRepository.php
+++ b/src/Place/CanonicalPlaceRepository.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace CultuurNet\UDB3\Place;
+
+class CanonicalPlaceRepository
+{
+    /**
+     * @var PlaceRepository
+     */
+    private $repository;
+
+    public function __construct(PlaceRepository $repository)
+    {
+        $this->repository = $repository;
+    }
+
+    public function findCanonicalFor(string $placeId): Place
+    {
+        /** @var Place $place */
+        $place = $this->repository->load($placeId);
+        while ($place->getCanonicalPlaceId()) {
+            $place = $this->repository->load($place->getCanonicalPlaceId());
+        }
+
+        return $place;
+    }
+}

--- a/src/Place/Place.php
+++ b/src/Place/Place.php
@@ -89,6 +89,11 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
      */
     private $duplicates = [];
 
+    /**
+     * @var string|null
+     */
+    private $canonicalPlaceId;
+
     public function __construct()
     {
         parent::__construct();
@@ -334,6 +339,7 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
     protected function applyMarkedAsDuplicate(MarkedAsDuplicate $event): void
     {
         $this->isDuplicate = true;
+        $this->canonicalPlaceId = $event->getDuplicateOf();
     }
 
     protected function applyMarkedAsCanonical(MarkedAsCanonical $event): void
@@ -342,6 +348,11 @@ class Place extends Offer implements UpdateableWithCdbXmlInterface
         foreach ($event->getDuplicatesOfDuplicate() as $duplicateOfDuplicate) {
             $this->duplicates[] = $duplicateOfDuplicate;
         }
+    }
+
+    public function getCanonicalPlaceId(): ?string
+    {
+        return $this->canonicalPlaceId;
     }
 
     /**

--- a/test/Event/RelocateEventToCanonicalPlaceTest.php
+++ b/test/Event/RelocateEventToCanonicalPlaceTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace CultuurNet\UDB3\Event;
+
+use Broadway\CommandHandling\Testing\TraceableCommandBus;
+use Broadway\Domain\DomainMessage;
+use Broadway\Domain\Metadata;
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Event\Commands\UpdateLocation;
+use CultuurNet\UDB3\Event\Events\EventCreated;
+use CultuurNet\UDB3\Event\Events\LocationUpdated;
+use CultuurNet\UDB3\Event\ValueObjects\LocationId;
+use CultuurNet\UDB3\Language;
+use CultuurNet\UDB3\Place\CanonicalPlaceRepository;
+use CultuurNet\UDB3\Place\Place;
+use CultuurNet\UDB3\Theme;
+use CultuurNet\UDB3\Title;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ValueObjects\Identity\UUID;
+
+class RelocateEventToCanonicalPlaceTest extends TestCase
+{
+    /**
+     * @var RelocateEventToCanonicalPlace
+     */
+    private $processManager;
+
+    /**
+     * @var TraceableCommandBus
+     */
+    private $commandBus;
+
+    /**
+     * @var CanonicalPlaceRepository | MockObject
+     */
+    private $canonicalPlaceRepository;
+
+    protected function setUp()
+    {
+        $this->commandBus = new TraceableCommandBus();
+        $this->canonicalPlaceRepository = $this->createMock(CanonicalPlaceRepository::class);
+
+        $this->processManager = new RelocateEventToCanonicalPlace(
+            $this->commandBus,
+            $this->canonicalPlaceRepository
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_not_relocate_events_when_they_already_use_a_canonical_place(): void
+    {
+        $eventId = Uuid::generateAsString();
+        $locationId = new LocationId(Uuid::generateAsString());
+        $place = $this->createMock(Place::class);
+        $place->method('getCanonicalPlaceId')->willReturn(null);
+        $place->method('getAggregateRootId')->willReturn($locationId->toNative());
+        $this->canonicalPlaceRepository->method('findCanonicalFor')->with($locationId)->willReturn($place);
+
+        $this->commandBus->record();
+        $this->broadcastNow(
+            new EventCreated(
+                $eventId,
+                new Language('en'),
+                new Title('Faith no More'),
+                new EventType('0.50.4.0.0', 'Concert'),
+                $locationId,
+                new Calendar(CalendarType::PERMANENT()),
+                new Theme('1.8.1.0.0', 'Rock')
+            )
+        );
+        $this->assertEmpty($this->commandBus->getRecordedCommands());
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_relocate_event_when_it_was_created_for_a_duplicate_place(): void
+    {
+        $eventId = Uuid::generateAsString();
+        $locationId = new LocationId(Uuid::generateAsString());
+        $canonicalPlaceId = Uuid::generateAsString();
+        $place = $this->createMock(Place::class);
+        $place->method('getCanonicalPlaceId')->willReturn($canonicalPlaceId);
+        $place->method('getAggregateRootId')->willReturn($canonicalPlaceId);
+        $this->canonicalPlaceRepository->method('findCanonicalFor')->with($locationId)->willReturn($place);
+
+        $this->commandBus->record();
+        $this->broadcastNow(
+            new EventCreated(
+                $eventId,
+                new Language('en'),
+                new Title('Faith no More'),
+                new EventType('0.50.4.0.0', 'Concert'),
+                $locationId,
+                new Calendar(CalendarType::PERMANENT()),
+                new Theme('1.8.1.0.0', 'Rock')
+            )
+        );
+        $this->assertEquals(
+            [
+                new UpdateLocation($eventId, new LocationId($canonicalPlaceId))
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_relocate_event_when_its_location_was_updated_to_a_duplicate_place(): void
+    {
+        $eventId = Uuid::generateAsString();
+        $locationId = new LocationId(Uuid::generateAsString());
+        $canonicalPlaceId = Uuid::generateAsString();
+        $place = $this->createMock(Place::class);
+        $place->method('getCanonicalPlaceId')->willReturn($canonicalPlaceId);
+        $place->method('getAggregateRootId')->willReturn($canonicalPlaceId);
+        $this->canonicalPlaceRepository->method('findCanonicalFor')->with($locationId)->willReturn($place);
+
+        $this->commandBus->record();
+        $this->broadcastNow(new LocationUpdated($eventId, $locationId));
+        $this->assertEquals(
+            [
+                new UpdateLocation($eventId, new LocationId($canonicalPlaceId))
+            ],
+            $this->commandBus->getRecordedCommands()
+        );
+    }
+
+    private function broadcastNow($event)
+    {
+        $this->processManager->handle(
+            DomainMessage::recordNow(
+                UUID::generateAsString(),
+                0,
+                Metadata::deserialize([]),
+                $event
+            )
+        );
+    }
+}

--- a/test/Event/RelocateEventToCanonicalPlaceTest.php
+++ b/test/Event/RelocateEventToCanonicalPlaceTest.php
@@ -102,7 +102,7 @@ class RelocateEventToCanonicalPlaceTest extends TestCase
         );
         $this->assertEquals(
             [
-                new UpdateLocation($eventId, new LocationId($canonicalPlaceId))
+                new UpdateLocation($eventId, new LocationId($canonicalPlaceId)),
             ],
             $this->commandBus->getRecordedCommands()
         );
@@ -125,7 +125,7 @@ class RelocateEventToCanonicalPlaceTest extends TestCase
         $this->broadcastNow(new LocationUpdated($eventId, $locationId));
         $this->assertEquals(
             [
-                new UpdateLocation($eventId, new LocationId($canonicalPlaceId))
+                new UpdateLocation($eventId, new LocationId($canonicalPlaceId)),
             ],
             $this->commandBus->getRecordedCommands()
         );

--- a/test/Place/CanonicalPlaceRepositoryTest.php
+++ b/test/Place/CanonicalPlaceRepositoryTest.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace CultuurNet\UDB3\Place;
+
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use ValueObjects\Identity\UUID;
+
+class CanonicalPlaceRepositoryTest extends TestCase
+{
+    /**
+     * @var CanonicalPlaceRepository
+     */
+    private $canonicalPlaceRepository;
+
+    /**
+     * @var PlaceRepository | MockObject
+     */
+    private $placeRepository;
+
+    protected function setUp()
+    {
+        $this->placeRepository = $this->createMock(PlaceRepository::class);
+        $this->canonicalPlaceRepository = new CanonicalPlaceRepository($this->placeRepository);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_place_without_defined_canonical(): void
+    {
+        $placeId = UUID::generateAsString();
+        $canonicalPlace = $this->createMock(Place::class);
+        $canonicalPlace->method('getCanonicalPlaceId')->willReturn(null);
+        $canonicalPlace->method('getAggregateRootId')->willReturn($placeId);
+        $this->placeRepository->method('load')->with($placeId)->willReturn($canonicalPlace);
+
+        $canonicalPlace = $this->canonicalPlaceRepository->findCanonicalFor($placeId);
+
+        $this->assertEquals($placeId, $canonicalPlace->getAggregateRootId());
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_canonical_place(): void
+    {
+        $placeId = UUID::generateAsString();
+        $place = $this->createMock(Place::class);
+        $place->method('getAggregateRootId')->willReturn($placeId);
+
+        $secondLevelDuplicatePlaceId = Uuid::generateAsString();
+        $secondLevelDuplicatePlace = $this->createMock(Place::class);
+        $secondLevelDuplicatePlace->method('getAggregateRootId')->willReturn($secondLevelDuplicatePlaceId);
+
+        $canonicalPlaceId = UUID::generateAsString();
+        $canonicalPlace = $this->createMock(Place::class);
+        $canonicalPlace->method('getAggregateRootId')->willReturn($canonicalPlaceId);
+
+        $place->method('getCanonicalPlaceId')->willReturn($secondLevelDuplicatePlaceId);
+        $this->placeRepository->expects($this->at(0))->method('load')->with($placeId)->willReturn($place);
+
+        $secondLevelDuplicatePlace->method('getCanonicalPlaceId')->willReturn($canonicalPlaceId);
+        $this->placeRepository->expects($this->at(1))->method('load')->with($secondLevelDuplicatePlaceId)->willReturn($secondLevelDuplicatePlace);
+
+        $canonicalPlace->method('getCanonicalPlaceId')->willReturn(null);
+        $this->placeRepository->expects($this->at(2))->method('load')->with($canonicalPlaceId)->willReturn($canonicalPlace);
+
+        $canonicalPlace = $this->canonicalPlaceRepository->findCanonicalFor($placeId);
+
+        $this->assertEquals($canonicalPlaceId, $canonicalPlace->getAggregateRootId());
+    }
+}


### PR DESCRIPTION
### Added
- Process manager to update locations to canonical places for events that were created or updated to use a place that was marked as a duplicate before

---
Ticket: https://jira.uitdatabank.be/browse/III-3047