### PR TITLE
Fix event cdbxml imports

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -339,14 +339,14 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
         $this->locationId = $locationUpdated->getLocationId();
     }
 
-    /**
-     * @param Audience $audience
-     */
     public function updateAudience(
         Audience $audience
-    ) {
+    ): void {
         $audienceType = $audience->getAudienceType();
-        if ($this->locationId->isDummyPlaceForEducation() && !$audienceType->sameValueAs(AudienceType::EDUCATION())) {
+        if ($this->locationId &&
+            $this->locationId->isDummyPlaceForEducation() &&
+            !$audienceType->sameValueAs(AudienceType::EDUCATION())
+        ) {
             throw IncompatibleAudienceType::forEvent($this->eventId, $audienceType);
         }
 


### PR DESCRIPTION
### Fixed

- The automatic `updateAudience` call failed because `$this->locationId` is `null` after a cdbxml import because we do not have the cdbxml id extractor service here. (Right after this step we do set the `$this->locationId` though because we call `UpdateLocation` from the cdbxml importer.)

---

https://jira.uitdatabank.be/browse/III-3069