### PR TITLE
Fix audienceType not being updatable after removing dummy location

### DIFF
--- a/src/Event/Event.php
+++ b/src/Event/Event.php
@@ -311,6 +311,11 @@ class Event extends Offer implements UpdateableWithCdbXmlInterface
         $this->apply(new MajorInfoUpdated($this->eventId, $title, $eventType, $location, $calendar, $theme));
     }
 
+    protected function applyMajorInfoUpdated(MajorInfoUpdated $majorInfoUpdated)
+    {
+        $this->locationId = $majorInfoUpdated->getLocation();
+    }
+
     /**
      * @param LocationId $locationId
      */

--- a/test/Event/EventCommandHandlerTest.php
+++ b/test/Event/EventCommandHandlerTest.php
@@ -443,6 +443,46 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
     /**
      * @test
      */
+    public function it_can_update_audience_after_switching_from_a_dummy_location_to_another_location_using_major_info()
+    {
+        // Mark the id used by $this->factorOfferCreated() as a dummy location.
+        LocationId::setDummyPlaceForEducationIds(['d0cd4e9d-3cf1-4324-9835-2bfba63ac015']);
+
+        $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';
+
+        $this->scenario
+            ->withAggregateId($eventId)
+            ->given(
+                [
+                    $this->factorOfferCreated($eventId),
+                    new UpdateMajorInfo(
+                        $eventId,
+                        new Title('some representative title'),
+                        new EventType('0.50.4.0.0', 'concert'),
+                        new LocationId('345afdf3-e670-4aa6-a4d2-b95ca081c18d'),
+                        new Calendar(CalendarType::PERMANENT())
+                    ),
+                ]
+            )
+            ->when(
+                new UpdateAudience(
+                    $eventId,
+                    new Audience(AudienceType::EDUCATION())
+                )
+            )
+            ->then(
+                [
+                    new AudienceUpdated(
+                        $eventId,
+                        new Audience(AudienceType::EDUCATION())
+                    ),
+                ]
+            );
+    }
+
+    /**
+     * @test
+     */
     public function it_should_ignore_updating_the_audience_when_the_same_audience_type_is_already_set()
     {
         $eventId = 'd2b41f1d-598c-46af-a3a5-10e373faa6fe';


### PR DESCRIPTION
### Fixed

- `audienceType` is now updatable after changing the location on an event from a dummy location to a regular location (using the deprecated major-info command).

---

Note that this will require `composer up cultuurnet/udb3` to be run in `udb3-silex` to update the dependency there after merging this.