### PR TITLE
III-3087 - Explicitly tell ImportLabels which labels it is allowed to remove

### DIFF
--- a/src/Offer/Commands/AbstractImportLabels.php
+++ b/src/Offer/Commands/AbstractImportLabels.php
@@ -20,6 +20,11 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
     private $labelsToKeepIfAlreadyOnOffer;
 
     /**
+     * @var Labels
+     */
+    private $labelsToRemoveWhenOnOffer;
+
+    /**
      * @param string $itemId
      * @param Labels $labels
      */
@@ -28,6 +33,7 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
         parent::__construct($itemId);
         $this->labels = $labels;
         $this->labelsToKeepIfAlreadyOnOffer = new Labels();
+        $this->labelsToRemoveWhenOnOffer = new Labels();
     }
 
     public function withLabelsToKeepIfAlreadyOnOffer(Labels $labels): self
@@ -40,6 +46,18 @@ abstract class AbstractImportLabels extends AbstractCommand implements LabelSecu
     public function getLabelsToKeepIfAlreadyOnOffer(): Labels
     {
         return $this->labelsToKeepIfAlreadyOnOffer;
+    }
+
+    public function withLabelsToRemoveWhenOnOffer(Labels $labels): self
+    {
+        $c = clone $this;
+        $c->labelsToRemoveWhenOnOffer = $labels;
+        return $c;
+    }
+
+    public function getLabelsToRemoveWhenOnOffer(): Labels
+    {
+        return $this->labelsToRemoveWhenOnOffer;
     }
 
     /**

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -328,7 +328,11 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     {
         $offer = $this->load($importLabels->getItemId());
 
-        $offer->importLabels($importLabels->getLabelsToImport(), $importLabels->getLabelsToKeepIfAlreadyOnOffer());
+        $offer->importLabels(
+            $importLabels->getLabelsToImport(),
+            $importLabels->getLabelsToKeepIfAlreadyOnOffer(),
+            $importLabels->getLabelsToRemoveWhenOnOffer()
+        );
 
         $this->offerRepository->save($offer);
     }

--- a/test/Offer/OfferCommandHandlerTest.php
+++ b/test/Offer/OfferCommandHandlerTest.php
@@ -315,13 +315,13 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
                         )
                     )
                 )->withLabelsToRemoveWhenOnOffer(
-                        new Labels(
-                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
-                                new LabelName('existing_to_be_removed'),
-                                true
-                            )
+                    new Labels(
+                        new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                            new LabelName('existing_to_be_removed'),
+                            true
                         )
                     )
+                )
             )
             ->then(
                 [

--- a/test/Offer/OfferCommandHandlerTest.php
+++ b/test/Offer/OfferCommandHandlerTest.php
@@ -314,13 +314,45 @@ class OfferCommandHandlerTest extends CommandHandlerScenarioTestCase
                             true
                         )
                     )
-                )
+                )->withLabelsToRemoveWhenOnOffer(
+                        new Labels(
+                            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                                new LabelName('existing_to_be_removed'),
+                                true
+                            )
+                        )
+                    )
             )
             ->then(
                 [
                     new LabelRemoved($this->id, new Label('existing_to_be_removed')),
                 ]
             );
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_not_remove_labels_that_were_added_after_import()
+    {
+        $this->scenario
+            ->withAggregateId($this->id)
+            ->given(
+                [
+                    $this->itemCreated,
+                    new LabelAdded($this->id, new Label('existing_added_async_after_import')),
+                    new LabelAdded($this->id, new Label('existing_private')),
+                ]
+            )
+            ->when(
+                (
+                new ImportLabels(
+                    $this->id,
+                    new Labels()
+                )
+                )
+            )
+            ->then([]);
     }
 
     /**

--- a/test/Offer/OfferTest.php
+++ b/test/Offer/OfferTest.php
@@ -386,6 +386,13 @@ class OfferTest extends AggregateRootScenarioTestCase
             )
         );
 
+        $labelsToRemoveWhenOnOffer = new Labels(
+            new \CultuurNet\UDB3\Model\ValueObject\Taxonomy\Label\Label(
+                new LabelName('existing_label_2'),
+                true
+            )
+        );
+
         $this->scenario
             ->given([
                 new ItemCreated($itemId),
@@ -394,9 +401,9 @@ class OfferTest extends AggregateRootScenarioTestCase
                 new LabelAdded($itemId, new Label('existing_label_3')),
             ])
             ->when(
-                function (Item $item) use ($labels, $labelsToKeepIfApplied) {
-                    $item->importLabels($labels, $labelsToKeepIfApplied);
-                    $item->importLabels($labels, $labelsToKeepIfApplied);
+                function (Item $item) use ($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer) {
+                    $item->importLabels($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer);
+                    $item->importLabels($labels, $labelsToKeepIfApplied, $labelsToRemoveWhenOnOffer);
                 }
             )
             ->then([


### PR DESCRIPTION
### Changed
- Importing labels now requires you specify which labels the import is allowed to remove from the offer. It used to remove all non-excluded labels, but that turned out to be too eager, also removing labels that were added async (e.g. uitpas)