### PR TITLE
III-3080 Find related events by using location.mainId instead of location.id

### DIFF
--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -52,7 +52,7 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListenerInte
         $duplicatePlaceId = $domainEvent->getPlaceId();
         $canonicalPlaceId = $domainEvent->getDuplicateOf();
 
-        $query = "location.id:{$duplicatePlaceId}";
+        $query = "location.mainId:{$duplicatePlaceId}";
         $results = $this->searchResultsGenerator->search($query);
 
         $updated = 0;

--- a/test/Event/LocationMarkedAsDuplicateProcessManagerTest.php
+++ b/test/Event/LocationMarkedAsDuplicateProcessManagerTest.php
@@ -75,7 +75,7 @@ class LocationMarkedAsDuplicateProcessManagerTest extends \PHPUnit_Framework_Tes
     {
         $this->searchResultsGenerator->expects($this->once())
             ->method('search')
-            ->with('location.id:110ecece-f6b0-4360-b5c5-c95babcfe045')
+            ->with('location.mainId:110ecece-f6b0-4360-b5c5-c95babcfe045')
             ->willReturn([
                 new IriOfferIdentifier(
                     Url::fromNative('http://www.uitdatabank.be/events/c393e98b-b33e-4948-b97a-3c48e3748398'),


### PR DESCRIPTION
### Changed

- The "location marked as duplicate" process manager now looks up the related events by using `location.mainId` instead of `location.id`, so we don't get events that are actually linked to the canonical place instead of the duplicate place