### PR TITLE
III-3080 Add more logging to SAPI3 results generator

### DIFF
--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -14,12 +14,15 @@ use CultuurNet\UDB3\Offer\OfferType;
 use CultuurNet\UDB3\Place\Events\MarkedAsDuplicate;
 use CultuurNet\UDB3\Search\ResultsGeneratorInterface;
 use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 final class LocationMarkedAsDuplicateProcessManager implements EventListenerInterface, LoggerAwareInterface
 {
-    use LoggerAwareTrait;
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
 
     /**
      * @var ResultsGeneratorInterface
@@ -40,7 +43,16 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListenerInte
         $this->logger = new NullLogger();
     }
 
-    public function handle(DomainMessage $domainMessage)
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
+
+        if ($this->searchResultsGenerator instanceof LoggerAwareInterface) {
+            $this->searchResultsGenerator->setLogger($logger);
+        }
+    }
+
+    public function handle(DomainMessage $domainMessage): void
     {
         $domainEvent = $domainMessage->getPayload();
 

--- a/src/Search/ResultsGenerator.php
+++ b/src/Search/ResultsGenerator.php
@@ -108,6 +108,8 @@ class ResultsGenerator implements LoggerAwareInterface, ResultsGeneratorInterfac
 
             $total = $results->getTotalItems()->toNative();
 
+            $this->logger->info('Search API reported ' . $total . ' results');
+
             foreach ($results->getItems() as $item) {
                 $id = $item->getId();
 


### PR DESCRIPTION
### Changed

- When marking a location as duplicate of another, we print more info to the CLI output (using a logger) so we can see how many events should be updated according to SAPI3 before we actually loop over them.

---

Ticket: https://jira.uitdatabank.be/browse/III-3080