### PR TITLE
III-3080 Fix pagination of events that should be relocated

### DIFF
--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -55,7 +55,7 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListenerInte
         $query = "location.mainId:{$duplicatePlaceId}";
         $results = $this->searchResultsGenerator->search($query);
 
-        $updated = 0;
+        $commands = [];
         $skipped = [];
 
         /* @var IriOfferIdentifier $result */
@@ -68,18 +68,23 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListenerInte
                 continue;
             }
 
-            $this->commandBus->dispatch(
-                new UpdateLocation($result->getId(), new LocationId($canonicalPlaceId))
-            );
-
-            $updated++;
+            // Keep all updates in-memory and dispatch them only after looping through all search results, as the
+            // pagination of results gets influenced by updating events in the loop.
+            $commands[] = new UpdateLocation($result->getId(), new LocationId($canonicalPlaceId));
 
             $this->logger->info(
                 'Dispatched UpdateLocation for result with id ' . $result->getId()
             );
         }
 
-        $this->logger->info('Received ' . ($updated + count($skipped)) . ' results from the search api.');
+        foreach ($commands as $command) {
+            $this->commandBus->dispatch($command);
+        }
+
+        $updated = count($commands);
+        $total = $updated + count($skipped);
+
+        $this->logger->info('Received ' . $total . ' results from the search api.');
         $this->logger->info('Updated ' . $updated . ' events to the canonical location.');
         $this->logger->info(
             'Skipped ' . count($skipped) . ' events:' . PHP_EOL . implode(PHP_EOL, $skipped)

--- a/src/Event/LocationMarkedAsDuplicateProcessManager.php
+++ b/src/Event/LocationMarkedAsDuplicateProcessManager.php
@@ -71,14 +71,14 @@ final class LocationMarkedAsDuplicateProcessManager implements EventListenerInte
             // Keep all updates in-memory and dispatch them only after looping through all search results, as the
             // pagination of results gets influenced by updating events in the loop.
             $commands[] = new UpdateLocation($result->getId(), new LocationId($canonicalPlaceId));
-
-            $this->logger->info(
-                'Dispatched UpdateLocation for result with id ' . $result->getId()
-            );
         }
 
         foreach ($commands as $command) {
             $this->commandBus->dispatch($command);
+
+            $this->logger->info(
+                'Dispatched UpdateLocation for result with id ' . $command->getItemId()
+            );
         }
 
         $updated = count($commands);


### PR DESCRIPTION
### Fixed

- Fixed the pagination of events that should be updated. Updating them influenced the search results and caused results to be shifted to other pages, so they got skipped.

---

Ticket: https://jira.uitdatabank.be/browse/III-3080