### PR TITLE
Fix queue consumers crashing on Add/RemoveLabel commands

### DIFF
--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -351,21 +351,6 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     }
 
     /**
-     * @param AbstractLabelCommand $labelCommand
-     * @return Label
-     */
-    private function createLabel(AbstractLabelCommand $labelCommand)
-    {
-        $labelName = new StringLiteral((string) $labelCommand->getLabel());
-        $label = $this->labelRepository->getByName($labelName);
-
-        return new Label(
-            $labelName->toNative(),
-            $label->getVisibility() === Visibility::VISIBLE()
-        );
-    }
-
-    /**
      * @param AbstractUpdateTitle $translateTitle
      */
     private function handleUpdateTitle(AbstractUpdateTitle $translateTitle)

--- a/src/Offer/OfferCommandHandler.php
+++ b/src/Offer/OfferCommandHandler.php
@@ -304,7 +304,18 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     {
         $offer = $this->load($addLabel->getItemId());
 
-        $offer->addLabel($this->createLabel($addLabel));
+        $labelName = (string) $addLabel->getLabel();
+        $labelVisibility = $addLabel->getLabel()->isVisible();
+
+        // Load the label read model so we can determine the correct visibility.
+        $labelEntity = $this->labelRepository->getByName(new StringLiteral($labelName));
+        if ($labelEntity instanceof Label\ReadModels\JSON\Repository\Entity) {
+            $labelVisibility = $labelEntity->getVisibility() === Visibility::VISIBLE();
+        }
+
+        $offer->addLabel(
+            new Label($labelName, $labelVisibility)
+        );
 
         $this->offerRepository->save($offer);
     }
@@ -316,7 +327,9 @@ abstract class OfferCommandHandler extends Udb3CommandHandler
     {
         $offer = $this->load($removeLabel->getItemId());
 
-        $offer->removeLabel($this->createLabel($removeLabel));
+        // Label visibility does not matter when removing, both the aggregate and the projectors remove the label from
+        // both the visible and hidden label lists.
+        $offer->removeLabel($removeLabel->getLabel());
 
         $this->offerRepository->save($offer);
     }

--- a/test/Event/EventCommandHandlerTest.php
+++ b/test/Event/EventCommandHandlerTest.php
@@ -245,7 +245,7 @@ class EventCommandHandlerTest extends CommandHandlerScenarioTestCase
                     new LabelAdded($id, new Label('bar', false)),
                 ]
             )
-            ->when(new RemoveLabel($id, new Label('bar')))
+            ->when(new RemoveLabel($id, new Label('bar', false)))
             ->then([new LabelRemoved($id, new Label('bar', false))]);
     }
 


### PR DESCRIPTION
### Fixed

- Some queue consumers dispatch Add/Remove label commands for labels that might not exist, and they are not automatically created by the EventEditingService in these cases.