### PR TITLE
Fix end dates in JsonLD projection of events with multiple dates 

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -181,7 +181,18 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
      */
     public function getStartDate()
     {
-        return $this->startDate;
+        if (empty($this->getTimestamps())) {
+            return $this->startDate;
+        }
+
+        $firstStartDate = $this->startDate;
+        foreach ($this->getTimestamps() as $timestamp) {
+            if ($timestamp->getStartDate() < $firstStartDate) {
+                $firstStartDate = $timestamp->getStartDate();
+            }
+        }
+
+        return $firstStartDate;
     }
 
     /**

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -189,7 +189,18 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
      */
     public function getEndDate()
     {
-        return $this->endDate;
+        if (empty($this->getTimestamps())) {
+            return $this->endDate;
+        }
+
+        $lastEndDate = $this->endDate;
+        foreach ($this->getTimestamps() as $timestamp) {
+            if ($timestamp->getEndDate() > $lastEndDate) {
+                $lastEndDate = $timestamp->getEndDate();
+            }
+        }
+
+        return $lastEndDate;
     }
 
     /**
@@ -250,7 +261,7 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
 
         return $jsonLd;
     }
-    
+
     /**
      * @param Calendar $otherCalendar
      * @return bool

--- a/src/CalendarFactory.php
+++ b/src/CalendarFactory.php
@@ -294,6 +294,7 @@ class CalendarFactory implements CalendarFactoryInterface
 
     /**
      * @param CultureFeed_Cdb_Data_Calendar_Timestamp[] $timestampList
+     * @param CultureFeed_Cdb_Data_Calendar_Timestamp $default
      * @return CultureFeed_Cdb_Data_Calendar_Timestamp
      */
     private function getLastTimestamp(array $timestampList, CultureFeed_Cdb_Data_Calendar_Timestamp $default)

--- a/src/CalendarFactory.php
+++ b/src/CalendarFactory.php
@@ -3,6 +3,7 @@
 namespace CultuurNet\UDB3;
 
 use Cake\Chronos\Chronos;
+use CultureFeed_Cdb_Data_Calendar_Timestamp;
 use CultuurNet\UDB3\Calendar\DayOfWeek;
 use CultuurNet\UDB3\Calendar\DayOfWeekCollection;
 use CultuurNet\UDB3\Calendar\OpeningHour;
@@ -50,7 +51,7 @@ class CalendarFactory implements CalendarFactoryInterface
             $firstTimestamp = $cdbCalendar->current();
             /** @var \CultureFeed_Cdb_Data_Calendar_Timestamp $timestamp */
             $cdbCalendarAsArray = iterator_to_array($cdbCalendar);
-            $timestamp = iterator_count($cdbCalendar) > 1 ? end($cdbCalendarAsArray) : $firstTimestamp;
+            $timestamp = $this->getLastTimestamp($cdbCalendarAsArray, $firstTimestamp);
             if ($timestamp->getEndTime()) {
                 $endDateString = $timestamp->getDate() . 'T' . $timestamp->getEndTime();
             } else {
@@ -289,5 +290,24 @@ class CalendarFactory implements CalendarFactoryInterface
         }
 
         return new Timestamp($startDate, $endDate);
+    }
+
+    /**
+     * @param CultureFeed_Cdb_Data_Calendar_Timestamp[] $timestampList
+     * @return CultureFeed_Cdb_Data_Calendar_Timestamp
+     */
+    private function getLastTimestamp(array $timestampList, CultureFeed_Cdb_Data_Calendar_Timestamp $default)
+    {
+        $lastTimestamp = $default;
+        $lastDate = null;
+        foreach ($timestampList as $timestamp) {
+            $endDate = Chronos::parse($timestamp->getEndDate());
+            if (!$lastDate || $lastDate < $endDate) {
+                $lastDate = $endDate;
+                $lastTimestamp = $timestamp;
+            }
+        }
+
+        return $lastTimestamp;
     }
 }

--- a/src/CalendarFactory.php
+++ b/src/CalendarFactory.php
@@ -28,8 +28,9 @@ class CalendarFactory implements CalendarFactoryInterface
             $period = $cdbCalendar->current();
             $startDateString = $period->getDateFrom() . 'T00:00:00';
         } elseif ($cdbCalendar instanceof \CultureFeed_Cdb_Data_Calendar_TimestampList) {
-            /** @var \CultureFeed_Cdb_Data_Calendar_Timestamp $timestamp */
-            $timestamp = $cdbCalendar->current();
+            $firstTimestamp = $cdbCalendar->current();
+            $cdbCalendarAsArray = iterator_to_array($cdbCalendar);
+            $timestamp = $this->getFirstTimestamp($cdbCalendarAsArray, $firstTimestamp);
             if ($timestamp->getStartTime()) {
                 $startDateString = $timestamp->getDate() . 'T' . substr($timestamp->getStartTime(), 0, 5) . ':00';
             } else {
@@ -303,11 +304,30 @@ class CalendarFactory implements CalendarFactoryInterface
         foreach ($timestampList as $timestamp) {
             $currentEndDate = Chronos::parse($lastTimestamp->getEndDate());
             $endDate = Chronos::parse($timestamp->getEndDate());
-            if ($currentEndDate < $endDate) {
+            if ($currentEndDate->lt($endDate)) {
                 $lastTimestamp = $timestamp;
             }
         }
 
         return $lastTimestamp;
+    }
+
+    /**
+     * @param CultureFeed_Cdb_Data_Calendar_Timestamp[] $timestampList
+     * @param CultureFeed_Cdb_Data_Calendar_Timestamp $default
+     * @return CultureFeed_Cdb_Data_Calendar_Timestamp
+     */
+    private function getFirstTimestamp(array $timestampList, CultureFeed_Cdb_Data_Calendar_Timestamp $default)
+    {
+        $firstTimestamp = $default;
+        foreach ($timestampList as $timestamp) {
+            $currentStartTime = Chronos::parse($firstTimestamp->getDate());
+            $startTime = Chronos::parse($timestamp->getDate());
+            if ($currentStartTime->gt($startTime)) {
+                $firstTimestamp = $timestamp;
+            }
+        }
+
+        return $firstTimestamp;
     }
 }

--- a/src/CalendarFactory.php
+++ b/src/CalendarFactory.php
@@ -299,11 +299,10 @@ class CalendarFactory implements CalendarFactoryInterface
     private function getLastTimestamp(array $timestampList, CultureFeed_Cdb_Data_Calendar_Timestamp $default)
     {
         $lastTimestamp = $default;
-        $lastDate = null;
         foreach ($timestampList as $timestamp) {
+            $currentEndDate = Chronos::parse($lastTimestamp->getEndDate());
             $endDate = Chronos::parse($timestamp->getEndDate());
-            if (!$lastDate || $lastDate < $endDate) {
-                $lastDate = $endDate;
+            if ($currentEndDate < $endDate) {
                 $lastTimestamp = $timestamp;
             }
         }

--- a/test/CalendarFactoryTest.php
+++ b/test/CalendarFactoryTest.php
@@ -317,14 +317,14 @@ class CalendarFactoryTest extends TestCase
                     $cdbCalendar = new CultureFeed_Cdb_Data_Calendar_TimestampList();
                     $cdbCalendar->add(
                         new CultureFeed_Cdb_Data_Calendar_Timestamp(
-                            "2017-05-21",
+                            "2017-07-21",
                             "00:00:00",
                             "23:59:00"
                         )
                     );
                     $cdbCalendar->add(
                         new CultureFeed_Cdb_Data_Calendar_Timestamp(
-                            "2017-07-21",
+                            "2017-05-21",
                             "00:00:00",
                             "23:59:00"
                         )
@@ -351,21 +351,21 @@ class CalendarFactoryTest extends TestCase
                     [
                         new Timestamp(
                             new DateTimeImmutable(
-                                '2017-05-21 00:00:00',
-                                $timeZone
-                            ),
-                            new DateTimeImmutable(
-                                '2017-05-21 23:59:00',
-                                $timeZone
-                            )
-                        ),
-                        new Timestamp(
-                            new DateTimeImmutable(
                                 '2017-07-21 00:00:00',
                                 $timeZone
                             ),
                             new DateTimeImmutable(
                                 '2017-07-21 23:59:00',
+                                $timeZone
+                            )
+                        ),
+                        new Timestamp(
+                            new DateTimeImmutable(
+                                '2017-05-21 00:00:00',
+                                $timeZone
+                            ),
+                            new DateTimeImmutable(
+                                '2017-05-21 23:59:00',
                                 $timeZone
                             )
                         ),

--- a/test/CalendarFactoryTest.php
+++ b/test/CalendarFactoryTest.php
@@ -312,6 +312,76 @@ class CalendarFactoryTest extends TestCase
                     ]
                 ),
             ],
+            'import event with multiple timestamps in non-chronological order: dates, no timestart or timeend' => [
+                'cdbCalendar' => call_user_func(function () {
+                    $cdbCalendar = new CultureFeed_Cdb_Data_Calendar_TimestampList();
+                    $cdbCalendar->add(
+                        new CultureFeed_Cdb_Data_Calendar_Timestamp(
+                            "2017-05-21",
+                            "00:00:00",
+                            "23:59:00"
+                        )
+                    );
+                    $cdbCalendar->add(
+                        new CultureFeed_Cdb_Data_Calendar_Timestamp(
+                            "2017-07-21",
+                            "00:00:00",
+                            "23:59:00"
+                        )
+                    );
+                    $cdbCalendar->add(
+                        new CultureFeed_Cdb_Data_Calendar_Timestamp(
+                            "2017-06-21",
+                            "00:00:00",
+                            "23:59:00"
+                        )
+                    );
+                    return $cdbCalendar;
+                }),
+                'expectedCalendar' => new Calendar(
+                    CalendarType::MULTIPLE(),
+                    new DateTimeImmutable(
+                        '2017-05-21 00:00:00',
+                        $timeZone
+                    ),
+                    new DateTimeImmutable(
+                        '2017-07-21 23:59:00',
+                        $timeZone
+                    ),
+                    [
+                        new Timestamp(
+                            new DateTimeImmutable(
+                                '2017-05-21 00:00:00',
+                                $timeZone
+                            ),
+                            new DateTimeImmutable(
+                                '2017-05-21 23:59:00',
+                                $timeZone
+                            )
+                        ),
+                        new Timestamp(
+                            new DateTimeImmutable(
+                                '2017-07-21 00:00:00',
+                                $timeZone
+                            ),
+                            new DateTimeImmutable(
+                                '2017-07-21 23:59:00',
+                                $timeZone
+                            )
+                        ),
+                        new Timestamp(
+                            new DateTimeImmutable(
+                                '2017-06-21 00:00:00',
+                                $timeZone
+                            ),
+                            new DateTimeImmutable(
+                                '2017-06-21 23:59:00',
+                                $timeZone
+                            )
+                        ),
+                    ]
+                ),
+            ],
             'import event with multiple timestamps: dates + timestart, no timeend' => [
                 'cdbCalendar' => call_user_func(function () {
                     $cdbCalendar = new CultureFeed_Cdb_Data_Calendar_TimestampList();


### PR DESCRIPTION
### Fixed 
- Projection of events with multiple dates incorrectly used the end date of the last added date instead of the chronological last date of the added timestamps.
- Projection of events with multiple dates incorrectly used the start date of the first added date instead of the chronological first date of the added timestamps.

---
Issue: https://jira.uitdatabank.be/browse/III-3132

---
After this is merged we should update this dependency in https://github.com/cultuurnet/udb3-silex