### PR TITLE
III-3132: Sort timestamps of events

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -84,8 +84,14 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
         $this->type = $type->toNative();
         $this->startDate = $startDate;
         $this->endDate = $endDate;
-        $this->timestamps = $timestamps;
         $this->openingHours = $openingHours;
+
+        usort($timestamps, function(Timestamp $timestamp, Timestamp $otherTimestamp) {
+            return $timestamp->getStartDate() <=> $otherTimestamp->getStartDate();
+        });
+
+        $this->timestamps = $timestamps;
+
     }
 
     /**

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -86,7 +86,7 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
         $this->endDate = $endDate;
         $this->openingHours = $openingHours;
 
-        usort($timestamps, function(Timestamp $timestamp, Timestamp $otherTimestamp) {
+        usort($timestamps, function (Timestamp $timestamp, Timestamp $otherTimestamp) {
             return $timestamp->getStartDate() <=> $otherTimestamp->getStartDate();
         });
 

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -628,4 +628,58 @@ class CalendarTest extends TestCase
         $this->assertTrue($calendar->sameAs($sameCalendar));
         $this->assertFalse($calendar->sameAs($otherCalendar));
     }
+
+    /**
+     * @test
+     */
+    public function it_should_return_timestamps_in_chronological_order(): void
+    {
+        $calendar = new Calendar(
+            CalendarType::MULTIPLE(),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-30T12:12:12+01:00'),
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+                ),
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+                ),
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+                ),
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+                ),
+            ]
+        );
+
+        $expected = [
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+            ),
+        ];
+
+        $this->assertEquals(
+            $expected,
+            $calendar->getTimestamps()
+        );
+    }
 }


### PR DESCRIPTION
### Changed
- Timestamps of events with multiple timestamps are now always sorted chronologically

---
Issue: https://jira.uitdatabank.be/browse/III-3132

---
Note that we have to update the dependency in `udb3-silex` before this will work