### PR TITLE
III-3433 Make start and end date optional for single and multiple calendars

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -61,6 +61,10 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
         array $timestamps = array(),
         array $openingHours = array()
     ) {
+        if (($type->is(CalendarType::SINGLE()) || $type->is(CalendarType::MULTIPLE())) && (empty($timestamps))) {
+            throw new \UnexpectedValueException('A single or multiple calendar should have timestamps.');
+        }
+
         if ($type->is(CalendarType::PERIODIC()) && (empty($startDate) || empty($endDate))) {
             throw new \UnexpectedValueException('A period should have a start- and end-date.');
         }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -61,10 +61,6 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
         array $timestamps = array(),
         array $openingHours = array()
     ) {
-        if (($type->is(CalendarType::MULTIPLE()) || $type->is(CalendarType::SINGLE())) && empty($startDate)) {
-            throw new \UnexpectedValueException('Start date can not be empty for calendar type: ' . $type . '.');
-        }
-
         if ($type->is(CalendarType::PERIODIC()) && (empty($startDate) || empty($endDate))) {
             throw new \UnexpectedValueException('A period should have a start- and end-date.');
         }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -145,7 +145,7 @@ class Calendar implements CalendarInterface, JsonLdSerializableInterface, Serial
         $defaultTimeStamps = [];
         if ($calendarType->sameValueAs(CalendarType::SINGLE()) || $calendarType->sameValueAs(CalendarType::MULTIPLE())) {
             $defaultTimeStampStartDate = !empty($data['startDate']) ? self::deserializeDateTime($data['startDate']) : null;
-            $defaultTimeStampEndDate = !empty($data['endDate']) ? self::deserializeDateTime($data['endDate']) : null;
+            $defaultTimeStampEndDate = !empty($data['endDate']) ? self::deserializeDateTime($data['endDate']) : $defaultTimeStampStartDate;
             $defaultTimeStamp = $defaultTimeStampStartDate && $defaultTimeStampEndDate ? new Timestamp($defaultTimeStampStartDate, $defaultTimeStampEndDate) : null;
             $defaultTimeStamps = $defaultTimeStamp ? [$defaultTimeStamp] : [];
         }

--- a/test/Calendar/CalendarConverterTest.php
+++ b/test/Calendar/CalendarConverterTest.php
@@ -7,6 +7,7 @@ use CultureFeed_Cdb_Data_Calendar_PeriodList;
 use CultureFeed_Cdb_Data_Calendar_Permanent;
 use CultuurNet\UDB3\Calendar;
 use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Model\ValueObject\Calendar\OpeningHours\Time;
 use CultuurNet\UDB3\Timestamp;
 use DateTime;
 use PHPUnit\Framework\TestCase;
@@ -349,9 +350,14 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-27T02:00:00+02:00'),
-            [],
+            null,
+            null,
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-27T02:00:00+02:00')
+                ),
+            ],
             []
         );
 
@@ -384,9 +390,14 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-28T02:00:00+02:00'),
-            [],
+            null,
+            null,
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-26T21:00:00+02:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-28T02:00:00+02:00')
+                ),
+            ],
             []
         );
 
@@ -436,9 +447,14 @@ class CalendarConverterTest extends TestCase
 
         $calendar = new Calendar(
             CalendarType::SINGLE(),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-01T09:00:00+02:00'),
-            DateTime::createFromFormat(DateTime::ATOM, '2017-05-07T18:00:00+02:00'),
-            [],
+            null,
+            null,
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-01T09:00:00+02:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2017-05-07T18:00:00+02:00')
+                ),
+            ],
             []
         );
 

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -311,6 +311,64 @@ class CalendarTest extends TestCase
 
     /**
      * @test
+     */
+    public function it_adds_a_timestamp_based_on_start_and_end_date_if_one_is_missing_for_single_calendars()
+    {
+        $invalidCalendarData = [
+            'type' => 'single',
+            'startDate' => '2016-03-06T10:00:00',
+            'endDate' => '2016-03-13T12:00:00',
+            'timestamps' => [],
+        ];
+
+        $expected = new Calendar(
+            CalendarType::SINGLE(),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                ),
+            ]
+        );
+
+        $actual = Calendar::deserialize($invalidCalendarData);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_timestamp_based_on_start_and_end_date_if_one_is_missing_for_multiple_calendars()
+    {
+        $invalidCalendarData = [
+            'type' => 'multiple',
+            'startDate' => '2016-03-06T10:00:00',
+            'endDate' => '2016-03-13T12:00:00',
+            'timestamps' => [],
+        ];
+
+        $expected = new Calendar(
+            CalendarType::MULTIPLE(),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                ),
+            ]
+        );
+
+        $actual = Calendar::deserialize($invalidCalendarData);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
      * @dataProvider periodicCalendarWithMissingDatesDataProvider
      * @param $calendarData
      */

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -168,7 +168,7 @@ class CalendarTest extends TestCase
         $this->expectExceptionMessage('OpeningHours should have type OpeningHour.');
 
         new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
             DateTime::createFromFormat(DateTime::ATOM, self::END_DATE),
             [],
@@ -214,25 +214,60 @@ class CalendarTest extends TestCase
             'single' => [
                 'calendar' => new Calendar(
                     CalendarType::SINGLE(),
-                    DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-                    DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+                    null,
+                    null,
+                    [
+                        new Timestamp(
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                        ),
+                    ]
                 ),
                 'jsonld' => [
                     'calendarType' => 'single',
                     'startDate' => '2016-03-06T10:00:00+01:00',
                     'endDate' => '2016-03-13T12:00:00+01:00',
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2016-03-06T10:00:00+01:00',
+                            'endDate' => '2016-03-13T12:00:00+01:00',
+                        ],
+                    ],
                 ],
             ],
             'multiple' => [
                 'calendar' => new Calendar(
                     CalendarType::MULTIPLE(),
-                    DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
-                    DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
+                    null,
+                    null,
+                    [
+                        new Timestamp(
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                        ),
+                        new Timestamp(
+                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00')
+                        ),
+                    ]
                 ),
                 'jsonld' => [
                     'calendarType' => 'multiple',
                     'startDate' => '2016-03-06T10:00:00+01:00',
-                    'endDate' => '2016-03-13T12:00:00+01:00',
+                    'endDate' => '2020-03-13T12:00:00+01:00',
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2016-03-06T10:00:00+01:00',
+                            'endDate' => '2016-03-13T12:00:00+01:00',
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-03-06T10:00:00+01:00',
+                            'endDate' => '2020-03-13T12:00:00+01:00',
+                        ],
+                    ],
                 ],
             ],
             'periodic' => [
@@ -264,14 +299,14 @@ class CalendarTest extends TestCase
     public function it_should_assume_the_timezone_is_Brussels_when_none_is_provided_when_deserializing()
     {
         $oldCalendarData = [
-            'type' => 'single',
+            'type' => 'periodic',
             'startDate' => '2016-03-06T10:00:00',
             'endDate' => '2016-03-13T12:00:00',
             'timestamps' => [],
         ];
 
         $expectedCalendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             DateTime::createFromFormat(DateTime::ATOM, self::START_DATE),
             DateTime::createFromFormat(DateTime::ATOM, self::END_DATE)
         );
@@ -612,19 +647,19 @@ class CalendarTest extends TestCase
     public function it_can_determine_same_calendars()
     {
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $sameCalendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
 
         $otherCalendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-28T12:12:12+01:00')
         );

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -102,37 +102,41 @@ class CalendarTest extends TestCase
 
     /**
      * @test
-     * @dataProvider calendarTypesWithStartDateProvider
+     * @dataProvider calendarTypesWithStartAndEndDateProvider
      * @param CalendarType $calendarType
      * @param string $expectedMessage
      * @param DateTimeInterface|null $startDate
+     * @param DateTimeInterface|null $endDate
      */
     public function it_should_expect_a_start_date_for_some_calendar_types(
         CalendarType $calendarType,
         $expectedMessage,
-        DateTimeInterface $startDate = null
+        DateTimeInterface $startDate = null,
+        DateTimeInterface $endDate = null
     ) {
         $this->expectException(UnexpectedValueException::class);
         $this->expectExceptionMessage($expectedMessage);
 
-        new Calendar($calendarType, $startDate);
+        new Calendar($calendarType, $startDate, $endDate);
     }
 
     /**
      * @return array
      */
-    public function calendarTypesWithStartDateProvider()
+    public function calendarTypesWithStartAndEndDateProvider(): array
     {
         return [
-            'for MULTIPLE calendar type' => [
-                'calendarType' => CalendarType::MULTIPLE(),
-                'expectedMessage' => 'Start date can not be empty for calendar type: multiple.',
+            'for PERIODIC calendar type without start date' => [
+                'calendarType' => CalendarType::PERIODIC(),
+                'expectedMessage' => 'A period should have a start- and end-date.',
                 'startDate' => null,
+                'endDate' => \DateTimeImmutable::createFromFormat(DATE_ATOM, '2020-01-01T00:00:00+02:00'),
             ],
-            'for SINGLE calendar type' => [
-                'calendarType' => CalendarType::SINGLE(),
-                'expectedMessage' => 'Start date can not be empty for calendar type: single.',
-                'startDate' => null,
+            'for PERIODIC calendar type without end date' => [
+                'calendarType' => CalendarType::PERIODIC(),
+                'expectedMessage' => 'A period should have a start- and end-date.',
+                'startDate' => \DateTimeImmutable::createFromFormat(DATE_ATOM, '2020-01-01T00:00:00+02:00'),
+                'endDate' => null,
             ],
         ];
     }

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -102,47 +102,6 @@ class CalendarTest extends TestCase
 
     /**
      * @test
-     * @dataProvider calendarTypesWithStartAndEndDateProvider
-     * @param CalendarType $calendarType
-     * @param string $expectedMessage
-     * @param DateTimeInterface|null $startDate
-     * @param DateTimeInterface|null $endDate
-     */
-    public function it_should_expect_a_start_date_for_some_calendar_types(
-        CalendarType $calendarType,
-        $expectedMessage,
-        DateTimeInterface $startDate = null,
-        DateTimeInterface $endDate = null
-    ) {
-        $this->expectException(UnexpectedValueException::class);
-        $this->expectExceptionMessage($expectedMessage);
-
-        new Calendar($calendarType, $startDate, $endDate);
-    }
-
-    /**
-     * @return array
-     */
-    public function calendarTypesWithStartAndEndDateProvider(): array
-    {
-        return [
-            'for PERIODIC calendar type without start date' => [
-                'calendarType' => CalendarType::PERIODIC(),
-                'expectedMessage' => 'A period should have a start- and end-date.',
-                'startDate' => null,
-                'endDate' => \DateTimeImmutable::createFromFormat(DATE_ATOM, '2020-01-01T00:00:00+02:00'),
-            ],
-            'for PERIODIC calendar type without end date' => [
-                'calendarType' => CalendarType::PERIODIC(),
-                'expectedMessage' => 'A period should have a start- and end-date.',
-                'startDate' => \DateTimeImmutable::createFromFormat(DATE_ATOM, '2020-01-01T00:00:00+02:00'),
-                'endDate' => null,
-            ],
-        ];
-    }
-
-    /**
-     * @test
      */
     public function time_stamps_need_to_have_type_time_stamp()
     {

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -341,6 +341,35 @@ class CalendarTest extends TestCase
     /**
      * @test
      */
+    public function it_adds_a_timestamp_based_on_start_date_if_one_is_missing_for_single_calendars()
+    {
+        $invalidCalendarData = [
+            'type' => 'single',
+            'startDate' => '2016-03-06T10:00:00',
+            'endDate' => null,
+            'timestamps' => [],
+        ];
+
+        $expected = new Calendar(
+            CalendarType::SINGLE(),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            null,
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00')
+                ),
+            ]
+        );
+
+        $actual = Calendar::deserialize($invalidCalendarData);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_adds_a_timestamp_based_on_start_and_end_date_if_one_is_missing_for_multiple_calendars()
     {
         $invalidCalendarData = [
@@ -358,6 +387,35 @@ class CalendarTest extends TestCase
                 new Timestamp(
                     DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
                     DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00')
+                ),
+            ]
+        );
+
+        $actual = Calendar::deserialize($invalidCalendarData);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_timestamp_based_on_start_date_if_one_is_missing_for_multiple_calendars()
+    {
+        $invalidCalendarData = [
+            'type' => 'multiple',
+            'startDate' => '2016-03-06T10:00:00',
+            'endDate' => null,
+            'timestamps' => [],
+        ];
+
+        $expected = new Calendar(
+            CalendarType::MULTIPLE(),
+            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+            null,
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                    DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00')
                 ),
             ]
         );

--- a/test/Event/Events/CalendarUpdatedTest.php
+++ b/test/Event/Events/CalendarUpdatedTest.php
@@ -33,17 +33,17 @@ class CalendarUpdatedTest extends TestCase
         $this->eventId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $this->calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
-            \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
+            \DateTime::createFromFormat(\DateTime::ATOM, '2021-01-27T12:12:12+01:00')
         );
 
         $this->calendarUpdatedAsArray = [
             'item_id' => '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a',
             'calendar' => [
-                'type' => 'single',
+                'type' => 'periodic',
                 'startDate' => '2020-01-26T11:11:11+01:00',
-                'endDate' => '2020-01-27T12:12:12+01:00',
+                'endDate' => '2021-01-27T12:12:12+01:00',
             ],
         ];
 

--- a/test/Event/Events/EventCopiedTest.php
+++ b/test/Event/Events/EventCopiedTest.php
@@ -40,8 +40,9 @@ class EventCopiedTest extends TestCase
         // explicitly to 0 in this test to make it pass.
         // See http://php.net/manual/en/migration71.incompatible.php#migration71.incompatible.datetime-microseconds.
         $this->calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new DateTime('2017-01-24T21:47:26.000000+0000')
+            CalendarType::PERIODIC(),
+            new DateTime('2017-01-24T21:47:26.000000+0000'),
+            new DateTime('2020-01-24T21:47:26.000000+0000')
         );
 
         $this->eventCopied = new EventCopied(
@@ -124,8 +125,9 @@ class EventCopiedTest extends TestCase
         $eventId = false;
         $originalEventId = '27105ae2-7e1c-425e-8266-4cb86a546159';
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERIODIC(),
+            new DateTime('2021-01-24T21:47:26.000000+0000'),
+            new DateTime('2022-01-24T21:47:26.000000+0000')
         );
 
         $this->expectException(\InvalidArgumentException::class);
@@ -144,8 +146,9 @@ class EventCopiedTest extends TestCase
         $eventId = 'e49430ca-5729-4768-8364-02ddb385517a';
         $originalEventId = false;
         $calendar = new Calendar(
-            CalendarType::SINGLE(),
-            new \DateTime()
+            CalendarType::PERIODIC(),
+            new DateTime('2021-01-24T21:47:26.000000+0000'),
+            new DateTime('2022-01-24T21:47:26.000000+0000')
         );
 
         $this->expectException(\InvalidArgumentException::class);

--- a/test/Place/Events/CalendarUpdatedTest.php
+++ b/test/Place/Events/CalendarUpdatedTest.php
@@ -33,7 +33,7 @@ class CalendarUpdatedTest extends TestCase
         $this->placeId = '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a';
 
         $this->calendar = new Calendar(
-            CalendarType::SINGLE(),
+            CalendarType::PERIODIC(),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-26T11:11:11+01:00'),
             \DateTime::createFromFormat(\DateTime::ATOM, '2020-01-27T12:12:12+01:00')
         );
@@ -41,7 +41,7 @@ class CalendarUpdatedTest extends TestCase
         $this->calendarUpdatedAsArray = [
             'item_id' => '0f4ea9ad-3681-4f3b-adc2-4b8b00dd845a',
             'calendar' => [
-                'type' => 'single',
+                'type' => 'periodic',
                 'startDate' => '2020-01-26T11:11:11+01:00',
                 'endDate' => '2020-01-27T12:12:12+01:00',
             ],


### PR DESCRIPTION
### Removed

- Removed requirement for start and end date for single and multiple calendars, as it can be determined based on the timestamps. This adds a hard requirement to pass timestamps though, which has a consequence for existing calendars in the event store which is why there's some backwards-compatibility workarounds.

---

Ticket: https://jira.uitdatabank.be/browse/III-3433

Related PR: https://github.com/cultuurnet/udb3-silex/pull/490

Note: This will require a `composer up cultuurnet/udb3` in https://github.com/cultuurnet/udb3-silex/pull/490 after this PR is merged