### PR TITLE
III-3570 Add events for sub event status changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-versions }}
                   extensions: intl
+                  tools: composer:v1
 
             - name: Check PHP Version
               run: php -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: vendor
-                  key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+                  key: ${{ runner.os }}-php-${{ matrix.php-versions }}
                   restore-keys: |
-                      ${{ runner.os }}-php-
+                      ${{ runner.os }}-php-${{ matrix.php-versions }}
 
             - name: Install dependencies
               if: steps.composer-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,7 @@ jobs:
             - name: Validate composer.json and composer.lock
               run: composer validate
 
-            - name: Cache Composer packages
-              id: composer-cache
-              uses: actions/cache@v2
-              with:
-                  path: vendor
-                  key: ${{ runner.os }}-php-${{ matrix.php-versions }}
-                  restore-keys: |
-                      ${{ runner.os }}-php-${{ matrix.php-versions }}
-
             - name: Install dependencies
-              if: steps.composer-cache.outputs.cache-hit != 'true'
               run: composer install --no-progress --no-suggest
 
             - name: Run Phing

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -227,6 +227,17 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         return $this->timestamps;
     }
 
+    public function hasTimestamp(Timestamp $timestampToSearch): bool
+    {
+        foreach ($this->timestamps as $timestamp) {
+            if ($timestamp->equals($timestampToSearch)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     public function toJsonLd(): array
     {
         $jsonLd = [];

--- a/src/Event/Events/Status/SubEventCancelled.php
+++ b/src/Event/Events/Status/SubEventCancelled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events\Status;
+
+final class SubEventCancelled extends SubEventStatusUpdated
+{
+}

--- a/src/Event/Events/Status/SubEventPostponed.php
+++ b/src/Event/Events/Status/SubEventPostponed.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events\Status;
+
+final class SubEventPostponed extends SubEventStatusUpdated
+{
+}

--- a/src/Event/Events/Status/SubEventScheduled.php
+++ b/src/Event/Events/Status/SubEventScheduled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events\Status;
+
+final class SubEventScheduled extends SubEventStatusUpdated
+{
+}

--- a/src/Event/Events/Status/SubEventStatusUpdated.php
+++ b/src/Event/Events/Status/SubEventStatusUpdated.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\Events\Status;
 
+use Broadway\Serializer\SerializableInterface;
 use CultuurNet\UDB3\Timestamp;
 
-abstract class SubEventStatusUpdated
+abstract class SubEventStatusUpdated implements SerializableInterface
 {
     /**
      * @var string

--- a/src/Event/Events/Status/SubEventStatusUpdated.php
+++ b/src/Event/Events/Status/SubEventStatusUpdated.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events\Status;
+
+use CultuurNet\UDB3\Timestamp;
+
+abstract class SubEventStatusUpdated
+{
+    /**
+     * @var string
+     */
+    private $eventId;
+
+    /**
+     * @var Timestamp
+     */
+    private $timestamp;
+
+    /**
+     * @var string
+     */
+    private $reason;
+
+    final public function __construct(string $eventId, Timestamp $timestamp, string $reason)
+    {
+        $this->eventId = $eventId;
+        $this->timestamp = $timestamp;
+        $this->reason = $reason;
+    }
+
+    public function serialize(): array
+    {
+        return [
+            'eventId' => $this->eventId,
+            'timestamp' => $this->timestamp->serialize(),
+            'reason' => $this->reason,
+        ];
+    }
+
+    /**
+     * @return static
+     */
+    public static function deserialize(array $data)
+    {
+        return new static(
+            $data['eventId'],
+            Timestamp::deserialize($data['timestamp']),
+            $data['reason']
+        );
+    }
+
+    public function getEventId(): string
+    {
+        return $this->eventId;
+    }
+
+    public function getTimestamp(): Timestamp
+    {
+        return $this->timestamp;
+    }
+
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+}

--- a/src/Event/ValueObjects/Status.php
+++ b/src/Event/ValueObjects/Status.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+class Status
+{
+    private const SCHEDULED = 'scheduled';
+    private const POSTPONED = 'postponed';
+    private const CANCELLED = 'cancelled';
+
+    /**
+     * @var string
+     */
+    private $value;
+
+    public function __construct(string $value)
+    {
+        $this->value = $value;
+    }
+
+    public static function scheduled(): Status
+    {
+        return new Status(self::SCHEDULED);
+    }
+
+    public static function postponed(): Status
+    {
+        return new Status(self::POSTPONED);
+    }
+
+    public static function cancelled(): Status
+    {
+        return new Status(self::CANCELLED);
+    }
+
+    public function toNative(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(Status $status): bool
+    {
+        return $this->value === $status->toNative();
+    }
+}

--- a/src/Event/ValueObjects/Status.php
+++ b/src/Event/ValueObjects/Status.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ValueObjects;
 
+use InvalidArgumentException;
+
 class Status
 {
     private const SCHEDULED = 'scheduled';
@@ -17,7 +19,19 @@ class Status
 
     private function __construct(string $value)
     {
+        if (!\in_array($value, $this->getAllowedValues())) {
+            throw new InvalidArgumentException('Status does not support the value "' . $value . '"');
+        }
         $this->value = $value;
+    }
+
+    private function getAllowedValues(): array
+    {
+        return [
+            self::SCHEDULED,
+            self::POSTPONED,
+            self::CANCELLED,
+        ];
     }
 
     public static function scheduled(): Status
@@ -38,6 +52,11 @@ class Status
     public function toNative(): string
     {
         return $this->value;
+    }
+
+    public static function fromNative(string $value): Status
+    {
+        return new Status($value);
     }
 
     public function equals(Status $status): bool

--- a/src/Event/ValueObjects/Status.php
+++ b/src/Event/ValueObjects/Status.php
@@ -15,7 +15,7 @@ class Status
      */
     private $value;
 
-    public function __construct(string $value)
+    private function __construct(string $value)
     {
         $this->value = $value;
     }

--- a/src/Event/ValueObjects/Status.php
+++ b/src/Event/ValueObjects/Status.php
@@ -17,21 +17,21 @@ class Status
      */
     private $value;
 
+    /**
+     * @var string[]
+     */
+    private const ALLOWED_VALUES = [
+        self::SCHEDULED,
+        self::POSTPONED,
+        self::CANCELLED,
+    ];
+
     private function __construct(string $value)
     {
-        if (!\in_array($value, $this->getAllowedValues())) {
+        if (!\in_array($value, self::ALLOWED_VALUES, true)) {
             throw new InvalidArgumentException('Status does not support the value "' . $value . '"');
         }
         $this->value = $value;
-    }
-
-    private function getAllowedValues(): array
-    {
-        return [
-            self::SCHEDULED,
-            self::POSTPONED,
-            self::CANCELLED,
-        ];
     }
 
     public static function scheduled(): Status

--- a/src/Event/ValueObjects/SubEvent.php
+++ b/src/Event/ValueObjects/SubEvent.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+use CultuurNet\UDB3\Timestamp;
+
+final class SubEvent
+{
+    /**
+     * @var Timestamp
+     */
+    private $timestamp;
+
+    /**
+     * @var Status
+     */
+    private $status;
+
+    public function __construct(Timestamp $timestamp, Status $status)
+    {
+        $this->timestamp = $timestamp;
+        $this->status = $status;
+    }
+
+    public function getTimestamp(): Timestamp
+    {
+        return $this->timestamp;
+    }
+
+    public function getStatus(): Status
+    {
+        return $this->status;
+    }
+
+    public function equals(SubEvent $otherSubEvent): bool
+    {
+        if (!$this->timestamp->equals($otherSubEvent->getTimestamp())) {
+            return false;
+        }
+
+        if (!$this->status->equals($otherSubEvent->getStatus())) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Event/ValueObjects/SubEvents.php
+++ b/src/Event/ValueObjects/SubEvents.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\Timestamp;
+
+final class SubEvents
+{
+    /**
+     * @var SubEvent[]
+     */
+    private $subEvents;
+
+    private function __construct(SubEvent ...$subEvents)
+    {
+        $this->subEvents = $subEvents;
+    }
+
+    public static function createEmpty(): SubEvents
+    {
+        return new SubEvents(...[]);
+    }
+
+    public static function createFromCalendar(Calendar $calendar): SubEvents
+    {
+        if (empty($calendar->getTimestamps())) {
+            return self::createEmpty();
+        }
+
+        $subEvents = [];
+        // TODO III-3570: Take into account a calendar with the same timestamps.
+        foreach ($calendar->getTimestamps() as $timestamp) {
+            $subEvents[] = new SubEvent($timestamp, Status::scheduled());
+        }
+
+        return new SubEvents(...$subEvents);
+    }
+
+    public function getSubEvents(): array
+    {
+        return $this->subEvents;
+    }
+
+    public function hasSubEvent(SubEvent $subEventToSearch): bool
+    {
+        foreach ($this->subEvents as $subEvent) {
+            if ($subEvent->equals($subEventToSearch)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasSubEventWithTimestamp(Timestamp $timestampToSearch): bool
+    {
+        foreach ($this->subEvents as $subEvent) {
+            if ($subEvent->getTimestamp()->equals($timestampToSearch)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function addSubEvent(SubEvent $subEvent): SubEvents
+    {
+        if ($this->hasSubEventWithTimestamp($subEvent->getTimestamp())) {
+            return $this;
+        }
+
+        $this->subEvents[] = $subEvent;
+
+        return $this;
+    }
+
+    public function updateSubEvent(SubEvent $subEvent): SubEvents
+    {
+        if (!$this->hasSubEventWithTimestamp($subEvent->getTimestamp())) {
+            return $this;
+        }
+
+        $this->removeSubEventWithTimestamp($subEvent->getTimestamp());
+        $this->subEvents[] = $subEvent;
+
+        return $this;
+    }
+
+    private function removeSubEventWithTimestamp(Timestamp $timestamp): SubEvents
+    {
+        $nrOfSubEvents = count($this->subEvents);
+        for ($index = 0; $index < $nrOfSubEvents; $index++) {
+            if ($this->subEvents[$index]->getTimestamp()->equals($timestamp)) {
+                unset($this->subEvents[$index]);
+            }
+        }
+
+        $this->subEvents = \array_values($this->subEvents);
+
+        return $this;
+    }
+}

--- a/src/Timestamp.php
+++ b/src/Timestamp.php
@@ -65,4 +65,9 @@ final class Timestamp implements SerializableInterface
             $dateRange->getTo()
         );
     }
+
+    public function equals(Timestamp $otherTimestamp): bool
+    {
+        return $this->serialize() === $otherTimestamp->serialize();
+    }
 }

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -791,4 +791,62 @@ class CalendarTest extends TestCase
             $calendar->getTimestamps()
         );
     }
+
+    /**
+     * @test
+     */
+    public function it_can_verify_if_it_has_a_certain_timestamp(): void
+    {
+        $calendar = new Calendar(
+            CalendarType::MULTIPLE(),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-03T12:12:12+01:00'),
+            [
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-02T12:12:12+01:00')
+                ),
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-02T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-03T12:12:12+01:00')
+                ),
+            ]
+        );
+
+        $this->assertTrue(
+            $calendar->hasTimestamp(
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-02T12:12:12+01:00')
+                )
+            )
+        );
+
+        $this->assertTrue(
+            $calendar->hasTimestamp(
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-02T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-03T12:12:12+01:00')
+                )
+            )
+        );
+
+        $this->assertFalse(
+            $calendar->hasTimestamp(
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-03T12:12:12+01:00')
+                )
+            )
+        );
+
+        $this->assertFalse(
+            $calendar->hasTimestamp(
+                new Timestamp(
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-06T11:11:11+01:00'),
+                    DateTime::createFromFormat(\DateTime::ATOM, '2020-04-06T12:12:12+01:00')
+                )
+            )
+        );
+    }
 }

--- a/test/Event/Events/Status/SubEventCancelledTest.php
+++ b/test/Event/Events/Status/SubEventCancelledTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\Events\Status;
+
+use CultuurNet\UDB3\Timestamp;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class SubEventCancelledTest extends TestCase
+{
+    /**
+     * @var SubEventCancelled
+     */
+    private $subEventCancelled;
+
+    /**
+     * @var array
+     */
+    private $subEventCancelledAsArray;
+
+    protected function setUp(): void
+    {
+        $this->subEventCancelled = new SubEventCancelled(
+            '376d4552-5bac-401d-a8ee-7a7fc639f25d',
+            new Timestamp(
+                new DateTime('2020-10-15T22:00:00+00:00'),
+                new DateTime('2020-10-16T21:59:59+00:00')
+            ),
+            'Cancelled sub event'
+        );
+
+        $this->subEventCancelledAsArray = [
+            'eventId' => '376d4552-5bac-401d-a8ee-7a7fc639f25d',
+            'timestamp' => [
+                'startDate' => '2020-10-15T22:00:00+00:00',
+                'endDate' => '2020-10-16T21:59:59+00:00',
+            ],
+            'reason' => 'Cancelled sub event',
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_serialize(): void
+    {
+        $this->assertEquals(
+            $this->subEventCancelledAsArray,
+            $this->subEventCancelled->serialize()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_deserialize(): void
+    {
+        $this->assertEquals(
+            $this->subEventCancelled,
+            SubEventCancelled::deserialize($this->subEventCancelledAsArray)
+        );
+    }
+}

--- a/test/Event/ValueObjects/StatusTest.php
+++ b/test/Event/ValueObjects/StatusTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CultuurNet\UDB3\Event\ValueObjects;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 class StatusTest extends TestCase
@@ -38,5 +39,16 @@ class StatusTest extends TestCase
                 false,
             ],
         ];
+    }
+
+    /**
+     * @test
+     */
+    public function ith_throws_on_unsupported_values(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Status does not support the value "unsupported"');
+
+        Status::fromNative('unsupported');
     }
 }

--- a/test/Event/ValueObjects/StatusTest.php
+++ b/test/Event/ValueObjects/StatusTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+use PHPUnit\Framework\TestCase;
+
+class StatusTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider statusProvider
+     */
+    public function it_can_test_for_equality(Status $otherStatus, bool $equal): void
+    {
+        $status = Status::cancelled();
+
+        $this->assertEquals(
+            $equal,
+            $status->equals($otherStatus)
+        );
+    }
+
+    public function statusProvider(): array
+    {
+        return [
+            'equal status' => [
+                Status::cancelled(),
+                true,
+            ],
+            'different postponed status' => [
+                Status::postponed(),
+                false,
+            ],
+            'different scheduled status' => [
+                Status::scheduled(),
+                false,
+            ],
+        ];
+    }
+}

--- a/test/Event/ValueObjects/SubEventTest.php
+++ b/test/Event/ValueObjects/SubEventTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+use CultuurNet\UDB3\Timestamp;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class SubEventTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider subEventProvider
+     */
+    public function it_can_check_for_equality(SubEvent $otherSubEvent, bool $equal): void
+    {
+        $subEvent = new SubEvent(
+            new Timestamp(
+                new DateTime('2016-01-03T01:01:01+01:00'),
+                new DateTime('2016-01-07T01:01:01+01:00')
+            ),
+            Status::scheduled()
+        );
+
+        $this->assertEquals(
+            $equal,
+            $subEvent->equals($otherSubEvent)
+        );
+    }
+
+    public function subEventProvider(): array
+    {
+        return [
+            'equal sub event' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2016-01-03T01:01:01+01:00'),
+                        new DateTime('2016-01-07T01:01:01+01:00')
+                    ),
+                    Status::scheduled()
+                ),
+                true,
+            ],
+            'sub event different status' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2016-01-03T01:01:01+01:00'),
+                        new DateTime('2016-01-07T01:01:01+01:00')
+                    ),
+                    Status::postponed()
+                ),
+                false,
+            ],
+            'sub event different timestamp' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2016-01-05T01:01:01+01:00'),
+                        new DateTime('2016-01-07T01:01:01+01:00')
+                    ),
+                    Status::scheduled()
+                ),
+                false,
+            ],
+        ];
+    }
+}

--- a/test/Event/ValueObjects/SubEventsTest.php
+++ b/test/Event/ValueObjects/SubEventsTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CultuurNet\UDB3\Event\ValueObjects;
+
+use CultuurNet\UDB3\Calendar;
+use CultuurNet\UDB3\CalendarType;
+use CultuurNet\UDB3\Timestamp;
+use DateTime;
+use PHPUnit\Framework\TestCase;
+
+class SubEventsTest extends TestCase
+{
+    /**
+     * @var Calendar
+     */
+    private $calendarMultipleType;
+
+    protected function setUp(): void
+    {
+        $this->calendarMultipleType = new Calendar(
+            CalendarType::SINGLE(),
+            new DateTime('2020-10-15T22:00:00+00:00'),
+            new DateTime('2020-10-20T21:59:59+00:00'),
+            [
+                new Timestamp(
+                    new DateTime('2020-10-15T22:00:00+00:00'),
+                    new DateTime('2020-10-16T21:59:59+00:00')
+                ),
+                new Timestamp(
+                    new DateTime('2020-10-17T22:00:00+00:00'),
+                    new DateTime('2020-10-18T21:59:59+00:00')
+                ),
+                new Timestamp(
+                    new DateTime('2020-10-19T22:00:00+00:00'),
+                    new DateTime('2020-10-20T21:59:59+00:00')
+                ),
+            ]
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_created_empty(): void
+    {
+        $emptySubEvents = SubEvents::createEmpty();
+
+        $this->assertEmpty($emptySubEvents->getSubEvents());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_be_created_from_calendar(): void
+    {
+        $this->assertEquals(
+            [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-15T22:00:00+00:00'),
+                        new DateTime('2020-10-16T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-17T22:00:00+00:00'),
+                        new DateTime('2020-10-18T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-19T22:00:00+00:00'),
+                        new DateTime('2020-10-20T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+            ],
+            SubEvents::createFromCalendar($this->calendarMultipleType)->getSubEvents()
+        );
+    }
+
+    /**
+     * @test
+     * @dataProvider subEventProvider
+     */
+    public function it_can_check_if_sub_event_is_present(SubEvent $subEvent, bool $equal): void
+    {
+        $subEvents = SubEvents::createFromCalendar($this->calendarMultipleType);
+
+        $this->assertEquals(
+            $equal,
+            $subEvents->hasSubEvent($subEvent)
+        );
+    }
+
+    public function subEventProvider(): array
+    {
+        return [
+            'equal sub event' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-15T22:00:00+00:00'),
+                        new DateTime('2020-10-16T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+                true,
+            ],
+            'sub event different status' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-15T22:00:00+00:00'),
+                        new DateTime('2020-10-16T21:59:59+00:00')
+                    ),
+                    Status::postponed()
+                ),
+                false,
+            ],
+            'sub event different timestamp' => [
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-15T22:00:00+00:00'),
+                        new DateTime('2020-10-18T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     * @dataProvider timestampProvider
+     */
+    public function it_can_check_if_sub_event_with_timestamp_is_present(Timestamp $timestamp, bool $equal): void
+    {
+        $subEvents = SubEvents::createFromCalendar($this->calendarMultipleType);
+
+        $this->assertEquals(
+            $equal,
+            $subEvents->hasSubEventWithTimestamp($timestamp)
+        );
+    }
+
+    public function timestampProvider(): array
+    {
+        return [
+            'equal timestamp' => [
+                new Timestamp(
+                    new DateTime('2020-10-15T22:00:00+00:00'),
+                    new DateTime('2020-10-16T21:59:59+00:00')
+                ),
+                true,
+            ],
+            'different timestamp' => [
+                new Timestamp(
+                    new DateTime('2020-10-15T22:00:00+00:00'),
+                    new DateTime('2020-10-18T21:59:59+00:00')
+                ),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_add_a_sub_event(): void
+    {
+        $subEvent = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-15T22:00:00+00:00'),
+                new DateTime('2020-10-16T21:59:59+00:00')
+            ),
+            Status::scheduled()
+        );
+        $subEventDifferentTimestamp = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-17T22:00:00+00:00'),
+                new DateTime('2020-10-18T21:59:59+00:00')
+            ),
+            Status::scheduled()
+        );
+        $subEventDifferentStatus = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-15T22:00:00+00:00'),
+                new DateTime('2020-10-16T21:59:59+00:00')
+            ),
+            Status::postponed()
+        );
+        $subEventDifferentTimestampAndStatus = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-18T22:00:00+00:00'),
+                new DateTime('2020-10-19T21:59:59+00:00')
+            ),
+            Status::postponed()
+        );
+        $sameSubEvent = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-15T22:00:00+00:00'),
+                new DateTime('2020-10-16T21:59:59+00:00')
+            ),
+            Status::scheduled()
+        );
+
+        $subEvents = SubEvents::createEmpty();
+        $subEvents->addSubEvent($subEvent);
+        $subEvents->addSubEvent($subEventDifferentTimestamp);
+        $subEvents->addSubEvent($subEventDifferentStatus);
+        $subEvents->addSubEvent($subEventDifferentTimestampAndStatus);
+        $subEvents->addSubEvent($sameSubEvent);
+
+        $this->assertEquals(
+            [
+                $subEvent,
+                $subEventDifferentTimestamp,
+                $subEventDifferentTimestampAndStatus,
+            ],
+            $subEvents->getSubEvents()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_update_a_sub_event_status(): void
+    {
+        $subEvent = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-15T22:00:00+00:00'),
+                new DateTime('2020-10-16T21:59:59+00:00')
+            ),
+            Status::scheduled()
+        );
+        $differentSubEvent = new SubEvent(
+            new Timestamp(
+                new DateTime('2020-10-18T22:00:00+00:00'),
+                new DateTime('2020-10-19T21:59:59+00:00')
+            ),
+            Status::postponed()
+        );
+
+        $subEvents = SubEvents::createEmpty();
+        $subEvents->addSubEvent($subEvent);
+        $subEvents->addSubEvent($differentSubEvent);
+
+        $subEvents->updateSubEvent(
+            new SubEvent(
+                new Timestamp(
+                    new DateTime('2020-10-18T22:00:00+00:00'),
+                    new DateTime('2020-10-19T21:59:59+00:00')
+                ),
+                Status::scheduled()
+            )
+        );
+
+        $this->assertEquals(
+            [
+                $subEvent,
+                new SubEvent(
+                    new Timestamp(
+                        new DateTime('2020-10-18T22:00:00+00:00'),
+                        new DateTime('2020-10-19T21:59:59+00:00')
+                    ),
+                    Status::scheduled()
+                ),
+            ],
+            $subEvents->getSubEvents()
+        );
+    }
+}

--- a/test/TimestampTest.php
+++ b/test/TimestampTest.php
@@ -72,4 +72,55 @@ class TimestampTest extends TestCase
             DateTime::createFromFormat(DateTime::ATOM, $pastDate)
         );
     }
+
+    /**
+     * @test
+     * @dataProvider timestampProvider
+     */
+    public function it_can_check_for_equality(Timestamp $otherTimestamp, bool $equal): void
+    {
+        $timestamp = new Timestamp(
+            new DateTime('2016-01-03T01:01:01+01:00'),
+            new DateTime('2016-01-07T01:01:01+01:00')
+        );
+
+        $this->assertEquals(
+            $equal,
+            $timestamp->equals($otherTimestamp)
+        );
+    }
+
+    public function timestampProvider(): array
+    {
+        return [
+            'equal timestamp' => [
+                new Timestamp(
+                    new DateTime('2016-01-03T01:01:01+01:00'),
+                    new DateTime('2016-01-07T01:01:01+01:00')
+                ),
+                true,
+            ],
+            'timestamp with different start date'=> [
+                new Timestamp(
+                    new DateTime('2016-01-05T01:01:01+01:00'),
+                    new DateTime('2016-01-07T01:01:01+01:00')
+                ),
+                false,
+            ],
+            'timestamp with different end date' => [
+                new Timestamp(
+                    new DateTime('2016-01-03T01:01:01+01:00'),
+                    new DateTime('2016-01-08T01:01:01+01:00')
+                ),
+                false,
+            ],
+            'timestamp with different start and end date' => [
+                new Timestamp(
+                    new DateTime('2016-01-05T01:01:01+01:00'),
+                    new DateTime('2016-01-09T01:01:01+01:00')
+                ),
+                false,
+            ],
+        ];
+    }
 }


### PR DESCRIPTION
### Added
 
- Add `Status` value object for event status
- Add events for sub event status changes:
    - `SubEventCancelled`
    - `SubEventPostponed`
    - `SubEventScheduled`
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3570
