### PR TITLE
III-3679 Fix an incorrect top status in the Calendar when projecting to JSON-LD

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -376,7 +376,7 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
     /**
      * If the calendar has subEvents (timestamps), and a status manually set through an import or full calendar update
      * through the API, the top status might be incorrect.
-     * For example the top status can not be Available if one of the subEvents is Unavailable.
+     * For example the top status can not be Available if all the subEvents are Unavailable or TemporarilyUnavailable.
      * However we want to be flexible in what we accept from API clients since otherwise they will have to implement a
      * lot of (new) logic to make sure the top status they're sending is correct.
      * So we accept the top status as-is, and correct it during projection.

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -97,17 +97,25 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         $this->status = new Status($this->deriveStatusTypeFromSubEvents(), []);
     }
 
-    public function withStatus(Status $status): self
+    /**
+     * Set $updateStatusInTimestamps to true when setting a new top status that should also be applied to all subEvents.
+     * Set it to false when constructing a Calendar object that's deserialized from JSON and you want to set the raw
+     * status without affecting the status in the subEvents.
+     */
+    public function withStatus(Status $status, bool $updateStatusInTimestamps = true): self
     {
         $clone = clone $this;
 
         $clone->status = $status;
-        $clone->timestamps = \array_map(
-            function (Timestamp $timestamp) use ($status) : Timestamp {
-                return $timestamp->withStatus($status);
-            },
-            $clone->getTimestamps()
-        );
+
+        if ($updateStatusInTimestamps) {
+            $clone->timestamps = \array_map(
+                function (Timestamp $timestamp) use ($status) : Timestamp {
+                    return $timestamp->withStatus($status);
+                },
+                $clone->getTimestamps()
+            );
+        }
 
         return $clone;
     }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -184,7 +184,7 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         );
 
         if (!empty($data['status'])) {
-            $calendar = $calendar->withStatus(Status::deserialize($data['status']));
+            $calendar->status = Status::deserialize($data['status']);
         }
 
         return $calendar;

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -97,26 +97,22 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         $this->status = new Status($this->deriveStatusTypeFromSubEvents(), []);
     }
 
-    /**
-     * Set $updateStatusInTimestamps to true when setting a new top status that should also be applied to all subEvents.
-     * Set it to false when constructing a Calendar object that's deserialized from JSON and you want to set the raw
-     * status without affecting the status in the subEvents.
-     */
-    public function withStatus(Status $status, bool $updateStatusInTimestamps = true): self
+    public function withStatus(Status $status): self
     {
         $clone = clone $this;
-
         $clone->status = $status;
+        return $clone;
+    }
 
-        if ($updateStatusInTimestamps) {
-            $clone->timestamps = \array_map(
-                function (Timestamp $timestamp) use ($status) : Timestamp {
-                    return $timestamp->withStatus($status);
-                },
-                $clone->getTimestamps()
-            );
-        }
-
+    public function withStatusOnTimestamps(Status $status): self
+    {
+        $clone = clone $this;
+        $clone->timestamps = \array_map(
+            function (Timestamp $timestamp) use ($status) : Timestamp {
+                return $timestamp->withStatus($status);
+            },
+            $clone->getTimestamps()
+        );
         return $clone;
     }
 

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -716,7 +716,8 @@ class CalendarTest extends TestCase
                             new StatusReason(new Language('nl'), 'Alles goed'),
                             new StatusReason(new Language('en'), 'All good'),
                         ]
-                    )
+                    ),
+                    false
                 ),
                 'jsonld' => [
                     'calendarType' => 'multiple',

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -680,6 +680,79 @@ class CalendarTest extends TestCase
                     ],
                 ],
             ],
+            'multiple with all sub events cancelled but an incorrect top status which should get corrected' => [
+                'calendar' => (new Calendar(
+                    CalendarType::MULTIPLE(),
+                    null,
+                    null,
+                    [
+                        new Timestamp(
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTime::ATOM, '2016-03-13T12:00:00+01:00'),
+                            new Status(
+                                StatusType::unavailable(),
+                                [
+                                    new StatusReason(new Language('nl'), 'Het is afgelast.'),
+                                    new StatusReason(new Language('fr'), 'Il a été annulé.'),
+                                ]
+                            )
+                        ),
+                        new Timestamp(
+                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-06T10:00:00+01:00'),
+                            DateTime::createFromFormat(DateTime::ATOM, '2020-03-13T12:00:00+01:00'),
+                            new Status(
+                                StatusType::unavailable(),
+                                [
+                                    new StatusReason(new Language('nl'), 'Nog erger, het is afgelast.'),
+                                    new StatusReason(new Language('fr'), 'Pire encore, il a été annulé.'),
+                                ]
+                            )
+                        ),
+                    ]
+                ))->withStatus(
+                    new Status(
+                        StatusType::available(),
+                        [
+                            new StatusReason(new Language('nl'), 'Alles goed'),
+                            new StatusReason(new Language('en'), 'All good'),
+                        ]
+                    )
+                ),
+                'jsonld' => [
+                    'calendarType' => 'multiple',
+                    'startDate' => '2016-03-06T10:00:00+01:00',
+                    'endDate' => '2020-03-13T12:00:00+01:00',
+                    'status' => [
+                        'type' => 'Unavailable',
+                    ],
+                    'subEvent' => [
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2016-03-06T10:00:00+01:00',
+                            'endDate' => '2016-03-13T12:00:00+01:00',
+                            'status' => [
+                                'type' => StatusType::unavailable()->toNative(),
+                                'reason' => [
+                                    'nl' => 'Het is afgelast.',
+                                    'fr' => 'Il a été annulé.',
+                                ],
+                            ],
+                        ],
+                        [
+                            '@type' => 'Event',
+                            'startDate' => '2020-03-06T10:00:00+01:00',
+                            'endDate' => '2020-03-13T12:00:00+01:00',
+                            'status' => [
+                                'type' => StatusType::unavailable()->toNative(),
+                                'reason' => [
+                                    'nl' => 'Nog erger, het is afgelast.',
+                                    'fr' => 'Pire encore, il a été annulé.',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
             'periodic' => [
                 'calendar' => new Calendar(
                     CalendarType::PERIODIC(),

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -1408,7 +1408,7 @@ class CalendarTest extends TestCase
     /**
      * @test
      */
-    public function it_can_change_top_status_and_subEvents_statuses(): void
+    public function it_can_change_top_status_and_timestamp_statuses(): void
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -716,8 +716,7 @@ class CalendarTest extends TestCase
                             new StatusReason(new Language('nl'), 'Alles goed'),
                             new StatusReason(new Language('en'), 'All good'),
                         ]
-                    ),
-                    false
+                    )
                 ),
                 'jsonld' => [
                     'calendarType' => 'multiple',
@@ -1360,7 +1359,56 @@ class CalendarTest extends TestCase
     /**
      * @test
      */
-    public function itCanChangeStatus(): void
+    public function it_can_change_top_status(): void
+    {
+        $timestamps = [
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-20T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-05T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-10T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-07T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-09T12:12:12+01:00')
+            ),
+            new Timestamp(
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-15T11:11:11+01:00'),
+                DateTime::createFromFormat(\DateTime::ATOM, '2020-04-25T12:12:12+01:00')
+            ),
+        ];
+
+        $calendar = new Calendar(
+            CalendarType::MULTIPLE(),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-01T11:11:11+01:00'),
+            DateTime::createFromFormat(\DateTime::ATOM, '2020-04-30T12:12:12+01:00'),
+            $timestamps
+        );
+
+        $this->assertEquals(
+            new Status(StatusType::available(), []),
+            $calendar->getStatus()
+        );
+
+        $newStatus = new Status(
+            StatusType::unavailable(),
+            [
+                new StatusReason(new Language('nl'), 'Het mag niet van de afgevaardigde van de eerste minister'),
+            ]
+        );
+
+        $updatedCalendar = $calendar->withStatus($newStatus);
+
+        $this->assertEquals($newStatus, $updatedCalendar->getStatus());
+        $this->assertEquals($timestamps, $updatedCalendar->getTimestamps());
+    }
+
+    /**
+     * @test
+     */
+    public function it_can_change_top_status_and_subEvents_statuses(): void
     {
         $calendar = new Calendar(
             CalendarType::MULTIPLE(),
@@ -1398,7 +1446,9 @@ class CalendarTest extends TestCase
             ]
         );
 
-        $updatedCalendar = $calendar->withStatus($newStatus);
+        $updatedCalendar = $calendar
+            ->withStatus($newStatus)
+            ->withStatusOnTimestamps($newStatus);
 
         $this->assertEquals($newStatus, $updatedCalendar->getStatus());
 


### PR DESCRIPTION
### Fixed
 
- Fixed issue with `Calendar::deserialize()` causing the status in subEvents to be overwritten by a previously derived top status
- When a `Calendar` object has a top status that is incorrect compared to the statuses in its subEvents, it will get corrected when projecting it to JSON-LD. That way we still have the originally submitted data in case there's a bug in the conversion, or if the logic should ever change. (Cases where this can happen is when updating the full Calendar through `UpdateCalendar` or `UpdateMajorInfo`)
 
---
Ticket: https://jira.uitdatabank.be/browse/III-3679

I've added additional info in the commit descriptions, so if you go through them one by one you can find extra context there.
