### PR TITLE
Add udb3-models top level status on udb3-php calendar

### DIFF
--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -330,38 +330,40 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
         return $this->toJsonLd() === $otherCalendar->toJsonLd();
     }
 
-    public static function fromUdb3ModelCalendar(Udb3ModelCalendar $calendar): Calendar
+    public static function fromUdb3ModelCalendar(Udb3ModelCalendar $udb3Calendar): Calendar
     {
-        $type = CalendarType::fromNative($calendar->getType()->toString());
+        $type = CalendarType::fromNative($udb3Calendar->getType()->toString());
 
         $startDate = null;
         $endDate = null;
         $timestamps = [];
         $openingHours = [];
 
-        if ($calendar instanceof CalendarWithDateRange) {
-            $startDate = $calendar->getStartDate();
-            $endDate = $calendar->getEndDate();
+        if ($udb3Calendar instanceof CalendarWithDateRange) {
+            $startDate = $udb3Calendar->getStartDate();
+            $endDate = $udb3Calendar->getEndDate();
         }
 
-        if ($calendar instanceof CalendarWithSubEvents) {
+        if ($udb3Calendar instanceof CalendarWithSubEvents) {
             $timestamps = array_map(
                 function (SubEvent $subEvent) {
                     return Timestamp::fromUdb3ModelSubEvent($subEvent);
                 },
-                $calendar->getSubEvents()->toArray()
+                $udb3Calendar->getSubEvents()->toArray()
             );
         }
 
-        if ($calendar instanceof CalendarWithOpeningHours) {
+        if ($udb3Calendar instanceof CalendarWithOpeningHours) {
             $openingHours = array_map(
                 function (Udb3ModelOpeningHour $openingHour) {
                     return OpeningHour::fromUdb3ModelOpeningHour($openingHour);
                 },
-                $calendar->getOpeningHours()->toArray()
+                $udb3Calendar->getOpeningHours()->toArray()
             );
         }
 
-        return new self($type, $startDate, $endDate, $timestamps, $openingHours);
+        $calendar =new self($type, $startDate, $endDate, $timestamps, $openingHours);
+        $calendar->status = Status::fromUdb3ModelStatus($udb3Calendar->getStatus());
+        return $calendar;
     }
 }

--- a/src/Calendar.php
+++ b/src/Calendar.php
@@ -362,7 +362,7 @@ final class Calendar implements CalendarInterface, JsonLdSerializableInterface, 
             );
         }
 
-        $calendar =new self($type, $startDate, $endDate, $timestamps, $openingHours);
+        $calendar = new self($type, $startDate, $endDate, $timestamps, $openingHours);
         $calendar->status = Status::fromUdb3ModelStatus($udb3Calendar->getStatus());
         return $calendar;
     }

--- a/test/CalendarTest.php
+++ b/test/CalendarTest.php
@@ -1160,6 +1160,22 @@ class CalendarTest extends TestCase
     /**
      * @test
      */
+    public function it_takes_into_account_udb3_model_calendar_status()
+    {
+        $udb3ModelCalendar = (new PermanentCalendar(new OpeningHours()))
+            ->withStatus(new Udb3ModelStatus(Udb3ModelStatusType::TemporarilyUnavailable()));
+
+        $expected = (new Calendar(CalendarType::PERMANENT()))
+            ->withStatus(new Status(StatusType::temporarilyUnavailable(), []));
+
+        $actual = Calendar::fromUdb3ModelCalendar($udb3ModelCalendar);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @test
+     */
     public function it_can_determine_same_calendars()
     {
         $calendar = new Calendar(


### PR DESCRIPTION
### Changed
 
- Take into account udb3-models Calendar top-level status when creating a udb3-php Calendar. But make sure to only modify the top-level status and leave the sub-events untouched.
 
---

Ticket: https://jira.uitdatabank.be/browse/III-3660
